### PR TITLE
Feat: User 상세 정보 조회 / HubManager 추가

### DIFF
--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -10,9 +10,9 @@ spring:
     gateway:
       routes:  # Spring Cloud Gateway의 라우팅 설정
         - id: auth-service
-          uri: lb://auth-service
+          uri: lb://user-service
           predicates:
-            - Path=/auth/signIn
+            - Path=/api/auth/**, /api/users/**, /api/hub-managers/**
         - id: hub-service
           uri: lb://hub-service
           predicates:

--- a/user/build.gradle
+++ b/user/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+	implementation 'com.github.ksuid:ksuid:1.1.2'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'io.jsonwebtoken:jjwt:0.12.6'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/user/build.gradle
+++ b/user/build.gradle
@@ -40,6 +40,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/user/build.gradle
+++ b/user/build.gradle
@@ -33,6 +33,8 @@ dependencies {
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+	implementation group: 'com.google.code.gson', name: 'gson', version: '2.11.0'
+
 	implementation 'com.github.ksuid:ksuid:1.1.2'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'io.jsonwebtoken:jjwt:0.12.6'

--- a/user/src/main/java/com/logistcshub/user/UserApplication.java
+++ b/user/src/main/java/com/logistcshub/user/UserApplication.java
@@ -2,8 +2,14 @@ package com.logistcshub.user;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
+
+import static org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO;
 
 @SpringBootApplication
+@EnableFeignClients
+@EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
 public class UserApplication {
 
 	public static void main(String[] args) {

--- a/user/src/main/java/com/logistcshub/user/application/DeliveryManagerMapper.java
+++ b/user/src/main/java/com/logistcshub/user/application/DeliveryManagerMapper.java
@@ -1,0 +1,20 @@
+package com.logistcshub.user.application;
+
+import com.logistcshub.user.domain.model.DeliveryManager;
+import com.logistcshub.user.presentation.request.DeliveryManagerCreate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DeliveryManagerMapper {
+
+    public DeliveryManager DeliveryManagerCreateToDeliveryManager(DeliveryManagerCreate deliveryManagerCreate,
+                                                                  String ksuid) {
+
+        return DeliveryManager.from(
+                ksuid,
+                deliveryManagerCreate.userId(),
+                deliveryManagerCreate.hubId(),
+                deliveryManagerCreate.deliveryManagerType()
+        );
+    }
+}

--- a/user/src/main/java/com/logistcshub/user/application/client/HubClient.java
+++ b/user/src/main/java/com/logistcshub/user/application/client/HubClient.java
@@ -12,5 +12,5 @@ import java.util.UUID;
 public interface HubClient {
 
     @GetMapping("/api/hubs/{id}")
-    ApiResponse<HubRequest> getHub(@PathVariable("id") UUID id);
+    ApiResponse<HubRequest> findHub(@PathVariable("id") UUID id);
 }

--- a/user/src/main/java/com/logistcshub/user/application/client/HubClient.java
+++ b/user/src/main/java/com/logistcshub/user/application/client/HubClient.java
@@ -1,16 +1,19 @@
 package com.logistcshub.user.application.client;
 
-import com.logistcshub.user.infrastructure.common.ApiResponse;
-import com.logistcshub.user.presentation.request.HubRequest;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 import java.util.UUID;
 
 @FeignClient(name = "hub-service")
 public interface HubClient {
-
     @GetMapping("/api/hubs/{id}")
-    ApiResponse<HubRequest> findHub(@PathVariable("id") UUID id);
+    ResponseEntity<?> getHub(@RequestHeader(value = "X-USER-ID") Long userId,
+                             @RequestHeader(value = "X-USER-ROLE") String role,
+                             @PathVariable UUID id);
+
 }
+

--- a/user/src/main/java/com/logistcshub/user/application/client/HubClient.java
+++ b/user/src/main/java/com/logistcshub/user/application/client/HubClient.java
@@ -1,0 +1,16 @@
+package com.logistcshub.user.application.client;
+
+import com.logistcshub.user.infrastructure.common.ApiResponse;
+import com.logistcshub.user.presentation.request.HubRequest;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.UUID;
+
+@FeignClient(name = "hub-service")
+public interface HubClient {
+
+    @GetMapping("/api/hubs/{id}")
+    ApiResponse<HubRequest> getHub(@PathVariable("id") UUID id);
+}

--- a/user/src/main/java/com/logistcshub/user/application/dtos/DeliveryManagerDto.java
+++ b/user/src/main/java/com/logistcshub/user/application/dtos/DeliveryManagerDto.java
@@ -1,0 +1,52 @@
+package com.logistcshub.user.application.dtos;
+
+import com.logistcshub.user.domain.model.DeliveryManager;
+import com.logistcshub.user.domain.model.DeliveryManagerType;
+import com.querydsl.core.annotations.QueryProjection;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record DeliveryManagerDto(Long id,
+                                 Long userId,
+                                 UUID hubId,
+                                 DeliveryManagerType deliveryManagerType,
+                                 LocalDateTime createdAt,
+                                 String createBy,
+                                 LocalDateTime updatedAt,
+                                 String updatedBy) implements Serializable {
+
+
+    public static DeliveryManagerDto from(DeliveryManager deliveryManager) {
+        return new DeliveryManagerDto(
+                deliveryManager.getId(),
+                deliveryManager.getUserId(),
+                deliveryManager.getHubId(),
+                deliveryManager.getDeliveryPersonType(),
+                deliveryManager.getCreatedAt(),
+                deliveryManager.getCreatedBy(),
+                deliveryManager.getUpdatedAt(),
+                deliveryManager.getUpdatedBy()
+        );
+    }
+
+    @QueryProjection
+    public DeliveryManagerDto(Long id,
+                              Long userId,
+                              UUID hubId,
+                              DeliveryManagerType deliveryManagerType,
+                              LocalDateTime createdAt,
+                              String createBy,
+                              LocalDateTime updatedAt,
+                              String updatedBy){
+        this.id = id;
+        this.userId = userId;
+        this.hubId = hubId;
+        this.deliveryManagerType = deliveryManagerType;
+        this.createdAt = createdAt;
+        this.createBy = createBy;
+        this.updatedAt = updatedAt;
+        this.updatedBy = updatedBy;
+    }
+}

--- a/user/src/main/java/com/logistcshub/user/application/dtos/HubDto.java
+++ b/user/src/main/java/com/logistcshub/user/application/dtos/HubDto.java
@@ -1,0 +1,7 @@
+package com.logistcshub.user.application.dtos;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+public record HubDto(UUID id, String name, String address, double let, double lng) implements Serializable {
+}

--- a/user/src/main/java/com/logistcshub/user/application/dtos/HubDto.java
+++ b/user/src/main/java/com/logistcshub/user/application/dtos/HubDto.java
@@ -3,5 +3,5 @@ package com.logistcshub.user.application.dtos;
 import java.io.Serializable;
 import java.util.UUID;
 
-public record HubDto(UUID id, String name, String address, double let, double lng) implements Serializable {
+public record HubDto(UUID id) implements Serializable {
 }

--- a/user/src/main/java/com/logistcshub/user/application/dtos/HubResponse.java
+++ b/user/src/main/java/com/logistcshub/user/application/dtos/HubResponse.java
@@ -1,0 +1,6 @@
+package com.logistcshub.user.application.dtos;
+
+import java.util.UUID;
+
+public record HubResponse(UUID id, String name, String address) {
+}

--- a/user/src/main/java/com/logistcshub/user/application/service/DeliveryManagerService.java
+++ b/user/src/main/java/com/logistcshub/user/application/service/DeliveryManagerService.java
@@ -1,0 +1,57 @@
+//package com.logistcshub.user.application.service;
+//
+//import com.github.ksuid.Ksuid;
+//import com.logistcshub.user.application.DeliveryManagerMapper;
+//import com.logistcshub.user.application.client.HubClient;
+//import com.logistcshub.user.application.dtos.DeliveryManagerDto;
+//import com.logistcshub.user.application.dtos.HubResponse;
+//import com.logistcshub.user.application.security.UserDetailsImpl;
+//import com.logistcshub.user.domain.model.DeliveryManager;
+//import com.logistcshub.user.domain.model.User;
+//import com.logistcshub.user.domain.model.UserRoleEnum;
+//import com.logistcshub.user.domain.repository.DeliveryManagerRepository;
+//import com.logistcshub.user.domain.repository.UserRepository;
+//import com.logistcshub.user.presentation.request.DeliveryManagerCreate;
+//import jakarta.persistence.EntityNotFoundException;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.stereotype.Service;
+//import org.springframework.transaction.annotation.Transactional;
+//
+//@Service
+//@RequiredArgsConstructor
+//public class DeliveryManagerService {
+//
+//    private final DeliveryManagerRepository deliveryManagerRepository;
+//    private final UserRepository userRepository;
+//    private final DeliveryManagerMapper deliveryManagerMapper;
+//    private final HubClient hubClient;
+//
+//    @Transactional
+//    public DeliveryManagerDto create(UserDetailsImpl userDetails,
+//                                     DeliveryManagerCreate deliveryManagerCreate) {
+//
+//        Long userId = userDetails.getUserId();
+//        UserRoleEnum role = userDetails.user().getRole();
+//
+//        User user = userRepository.findById(deliveryManagerCreate.userId())
+//                .orElseThrow(() -> new EntityNotFoundException("등록하지 않은 유저입니다."));
+//
+//        // 소속된 허브 존재 여부
+//        if (role.equals(UserRoleEnum.HUB_MANAGER)) {
+//            HubResponse hub = hubClient.getHub(deliveryManagerCreate.hubId());
+//
+//            if (!hub.id().equals(deliveryManagerCreate.hubId())) {
+//
+//            }
+//        }
+//
+//            String ksuid = Ksuid.newKsuid().toString();
+//
+//            DeliveryManager createdDeliveryManager =
+//                    deliveryManagerMapper
+//                            .DeliveryManagerCreateToDeliveryManager(deliveryManagerCreate, ksuid);
+//
+//            return DeliveryManagerDto.from(deliveryManagerRepository.save(createdDeliveryManager));
+//
+//    }
+//}

--- a/user/src/main/java/com/logistcshub/user/application/service/HubManagerService.java
+++ b/user/src/main/java/com/logistcshub/user/application/service/HubManagerService.java
@@ -1,0 +1,57 @@
+package com.logistcshub.user.application.service;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import com.logistcshub.user.application.client.HubClient;
+import com.logistcshub.user.application.dtos.HubDto;
+import com.logistcshub.user.application.security.UserDetailsImpl;
+import com.logistcshub.user.domain.model.HubManager;
+import com.logistcshub.user.domain.model.User;
+import com.logistcshub.user.domain.repository.HubManagerRepository;
+import com.logistcshub.user.domain.repository.UserRepository;
+import com.logistcshub.user.presentation.request.HubManagerRequest;
+import com.logistcshub.user.presentation.response.HubManagerResponse;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class HubManagerService {
+
+    private final UserRepository userRepository;
+    private final HubManagerRepository hubManagerRepository;
+    private final HubClient hubClient;
+
+    public HubManagerResponse createHubManager(UserDetailsImpl userDetails, HubManagerRequest hubManagerRequest) {
+
+        User user = userRepository.findById(hubManagerRequest.userId())
+                .orElseThrow(() -> new EntityNotFoundException("등록하지 않은 유저입니다."));
+
+        Long userId = userDetails.getUserId();
+        String role = String.valueOf(userDetails.user().getRole());
+
+        // HubId 가져오기
+        ResponseEntity<?> responseEntity = hubClient.getHub(userId, role, hubManagerRequest.hubId());
+
+        Map<String, Object> responseBody = (Map<String, Object>) responseEntity.getBody();
+        Gson gson = new Gson();
+
+        String contentJson = gson.toJson(
+                ((Map<?, ?>) responseBody.get("data"))
+        );
+
+        Type listType = new TypeToken<HubDto>() {}.getType();
+        HubDto hub = gson.fromJson(contentJson, listType);
+
+        HubManager hubManager = HubManager.create(user, hub.id());
+
+        hubManagerRepository.save(hubManager);
+
+        return HubManagerResponse.of(hubManager);
+    }
+}

--- a/user/src/main/java/com/logistcshub/user/application/service/UserService.java
+++ b/user/src/main/java/com/logistcshub/user/application/service/UserService.java
@@ -55,4 +55,11 @@ public class UserService {
 
         return user.getUsername() + " 회원님 탈퇴 완로 되었습니다.";
     }
+
+    public UserDto get(Long id) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("등록하지 않은 유저입니다."));
+
+        return UserDto.of(user);
+    }
 }

--- a/user/src/main/java/com/logistcshub/user/application/service/UserService.java
+++ b/user/src/main/java/com/logistcshub/user/application/service/UserService.java
@@ -1,19 +1,32 @@
 package com.logistcshub.user.application.service;
 
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import com.logistcshub.user.application.client.HubClient;
+import com.logistcshub.user.application.dtos.HubDto;
 import com.logistcshub.user.application.dtos.MyInfoDto;
+import com.logistcshub.user.application.security.UserDetailsImpl;
+import com.logistcshub.user.domain.model.HubManager;
+import com.logistcshub.user.domain.repository.HubManagerRepository;
 import com.logistcshub.user.infrastructure.common.SearchResponse;
 import com.logistcshub.user.application.dtos.UserDto;
 import com.logistcshub.user.domain.model.User;
 import com.logistcshub.user.domain.model.UserRoleEnum;
 import com.logistcshub.user.domain.repository.UserRepository;
+import com.logistcshub.user.presentation.request.HubManagerRequest;
 import com.logistcshub.user.presentation.request.SearchRequest;
 import com.logistcshub.user.presentation.request.UserUpdateRequest;
+import com.logistcshub.user.presentation.response.HubManagerResponse;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.lang.reflect.Type;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -60,4 +73,5 @@ public class UserService {
 
         return UserDto.of(user);
     }
+
 }

--- a/user/src/main/java/com/logistcshub/user/application/service/UserService.java
+++ b/user/src/main/java/com/logistcshub/user/application/service/UserService.java
@@ -1,13 +1,11 @@
 package com.logistcshub.user.application.service;
 
 import com.logistcshub.user.application.dtos.MyInfoDto;
-import com.logistcshub.user.application.dtos.SearchResponse;
+import com.logistcshub.user.infrastructure.common.SearchResponse;
 import com.logistcshub.user.application.dtos.UserDto;
 import com.logistcshub.user.domain.model.User;
 import com.logistcshub.user.domain.model.UserRoleEnum;
 import com.logistcshub.user.domain.repository.UserRepository;
-import com.logistcshub.user.infrastructure.common.PageResponse;
-import com.logistcshub.user.infrastructure.common.SearchParameter;
 import com.logistcshub.user.presentation.request.SearchRequest;
 import com.logistcshub.user.presentation.request.UserUpdateRequest;
 import jakarta.persistence.EntityNotFoundException;

--- a/user/src/main/java/com/logistcshub/user/application/service/UserService.java
+++ b/user/src/main/java/com/logistcshub/user/application/service/UserService.java
@@ -51,7 +51,7 @@ public class UserService {
                 .orElseThrow(() -> new EntityNotFoundException("등록하지 않은 유저입니다."));
 
         // 논리적 삭제
-        user.delete(id);
+        user.delete(user.getEmail());
 
         return user.getUsername() + " 회원님 탈퇴 완로 되었습니다.";
     }

--- a/user/src/main/java/com/logistcshub/user/domain/model/DeliveryManager.java
+++ b/user/src/main/java/com/logistcshub/user/domain/model/DeliveryManager.java
@@ -16,7 +16,10 @@ public class DeliveryManager extends AuditEntity {
 
     @Id
     @Column(nullable = false)
-    private Long id;
+    private Long id; // 사용자 관리 엔티티의 사용자 Id
+
+    @Column(nullable = false, unique = true)
+    private String ksuid; // Ksuid를 별도로 저장
 
     @Column(nullable = false)
     private Long userId;
@@ -28,17 +31,18 @@ public class DeliveryManager extends AuditEntity {
     @Enumerated(EnumType.STRING)
     private DeliveryManagerType deliveryPersonType;
 
-    @Column(nullable = false, unique = true)
-    private Long deliverySequence;
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private DeliveryStatus status = DeliveryStatus.COMPLETED;
 
     // 배송 담당자 등록
-    public static DeliveryManager create(Long userId, UUID hubId, DeliveryManagerType deliveryPersonType, Long deliverySequence) {
+    public static DeliveryManager from(String ksuid, Long userId, UUID hubId, DeliveryManagerType deliveryPersonType) {
         return DeliveryManager.builder()
                 .id(userId)
+                .ksuid(ksuid)
                 .userId(userId)
                 .hubId(hubId)
                 .deliveryPersonType(deliveryPersonType)
-                .deliverySequence(userId)
                 .build();
     }
 }

--- a/user/src/main/java/com/logistcshub/user/domain/model/DeliveryManager.java
+++ b/user/src/main/java/com/logistcshub/user/domain/model/DeliveryManager.java
@@ -3,7 +3,6 @@ package com.logistcshub.user.domain.model;
 import com.logistcshub.user.infrastructure.common.AuditEntity;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.UuidGenerator;
 
 import java.util.UUID;
 
@@ -29,13 +28,17 @@ public class DeliveryManager extends AuditEntity {
     @Enumerated(EnumType.STRING)
     private DeliveryManagerType deliveryPersonType;
 
+    @Column(nullable = false, unique = true)
+    private Long deliverySequence;
+
     // 배송 담당자 등록
-    public static DeliveryManager create(Long userId, UUID hubId, DeliveryManagerType deliveryPersonType) {
+    public static DeliveryManager create(Long userId, UUID hubId, DeliveryManagerType deliveryPersonType, Long deliverySequence) {
         return DeliveryManager.builder()
                 .id(userId)
                 .userId(userId)
                 .hubId(hubId)
                 .deliveryPersonType(deliveryPersonType)
+                .deliverySequence(userId)
                 .build();
     }
 }

--- a/user/src/main/java/com/logistcshub/user/domain/model/DeliveryManager.java
+++ b/user/src/main/java/com/logistcshub/user/domain/model/DeliveryManager.java
@@ -1,0 +1,41 @@
+package com.logistcshub.user.domain.model;
+
+import com.logistcshub.user.infrastructure.common.AuditEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_delivery_managers")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class DeliveryManager extends AuditEntity {
+
+    @Id
+    @Column(nullable = false)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column
+    private UUID hubId;
+
+    @Column(nullable = false, length = 50)
+    @Enumerated(EnumType.STRING)
+    private DeliveryManagerType deliveryPersonType;
+
+    // 배송 담당자 등록
+    public static DeliveryManager create(Long userId, UUID hubId, DeliveryManagerType deliveryPersonType) {
+        return DeliveryManager.builder()
+                .id(userId)
+                .userId(userId)
+                .hubId(hubId)
+                .deliveryPersonType(deliveryPersonType)
+                .build();
+    }
+}

--- a/user/src/main/java/com/logistcshub/user/domain/model/DeliveryManagerType.java
+++ b/user/src/main/java/com/logistcshub/user/domain/model/DeliveryManagerType.java
@@ -1,5 +1,14 @@
 package com.logistcshub.user.domain.model;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum DeliveryManagerType {
+    HUB_PIC("HUB_PIC"),
+    COMPANY_PIC("COMPANY_PIC");
+
+    private final String type;
 
 }

--- a/user/src/main/java/com/logistcshub/user/domain/model/DeliveryManagerType.java
+++ b/user/src/main/java/com/logistcshub/user/domain/model/DeliveryManagerType.java
@@ -1,0 +1,5 @@
+package com.logistcshub.user.domain.model;
+
+public enum DeliveryManagerType {
+
+}

--- a/user/src/main/java/com/logistcshub/user/domain/model/DeliveryStatus.java
+++ b/user/src/main/java/com/logistcshub/user/domain/model/DeliveryStatus.java
@@ -1,0 +1,6 @@
+package com.logistcshub.user.domain.model;
+
+public enum DeliveryStatus {
+    ON_DELIVERY,
+    COMPLETED
+}

--- a/user/src/main/java/com/logistcshub/user/domain/model/HubManager.java
+++ b/user/src/main/java/com/logistcshub/user/domain/model/HubManager.java
@@ -1,0 +1,33 @@
+package com.logistcshub.user.domain.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.UUID;
+
+@Table(name = "p_hub_managers")
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class HubManager {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column
+    private UUID hubId;
+
+    public static HubManager create(User user, UUID hubId) {
+        return HubManager.builder()
+                .user(user)
+                .hubId(hubId)
+                .build();
+    }
+}

--- a/user/src/main/java/com/logistcshub/user/domain/model/User.java
+++ b/user/src/main/java/com/logistcshub/user/domain/model/User.java
@@ -1,5 +1,6 @@
 package com.logistcshub.user.domain.model;
 
+import com.logistcshub.user.infrastructure.common.AuditEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -18,7 +19,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder(access = AccessLevel.PRIVATE)
-public class User {
+public class User extends AuditEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -43,31 +44,6 @@ public class User {
     @Enumerated(EnumType.STRING)
     private UserRoleEnum role;
 
-    @Column(nullable = false)
-    private boolean isDelete = false;
-
-    @CreatedDate
-    @Column(updatable = false)
-    private LocalDateTime createdAt;
-
-    @CreatedBy
-    @Column(updatable = false)
-    private String createdBy;
-
-    @LastModifiedDate
-    @Column
-    private LocalDateTime updatedAt;
-
-    @LastModifiedBy
-    @Column
-    private String updatedBy;
-
-    @Column
-    private LocalDateTime deletedAt;
-
-    @Column
-    private String deletedBy;
-
     // 유저 생성
     public static User create(String username, String password, String email, String tel, String slackId, UserRoleEnum role) {
         return User.builder()
@@ -77,18 +53,10 @@ public class User {
                 .tel(tel)
                 .slackId(slackId)
                 .role(role)
-                .createdAt(LocalDateTime.now())
-                .createdBy(username)
                 .build();
     }
 
     public void updateUserRole(UserRoleEnum role) {
         this.role = role;
-    }
-
-    public void delete(Long id) {
-        deletedAt = LocalDateTime.now();
-        deletedBy = "MASTER";
-        isDelete = true;
     }
 }

--- a/user/src/main/java/com/logistcshub/user/domain/repository/DeliveryManagerRepository.java
+++ b/user/src/main/java/com/logistcshub/user/domain/repository/DeliveryManagerRepository.java
@@ -1,0 +1,7 @@
+package com.logistcshub.user.domain.repository;
+
+import com.logistcshub.user.domain.model.DeliveryManager;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DeliveryManagerRepository extends JpaRepository<DeliveryManager, Long> {
+}

--- a/user/src/main/java/com/logistcshub/user/domain/repository/HubManagerRepository.java
+++ b/user/src/main/java/com/logistcshub/user/domain/repository/HubManagerRepository.java
@@ -1,0 +1,9 @@
+package com.logistcshub.user.domain.repository;
+
+import com.logistcshub.user.domain.model.HubManager;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface HubManagerRepository extends JpaRepository<HubManager, UUID> {
+}

--- a/user/src/main/java/com/logistcshub/user/infrastructure/common/AuditEntity.java
+++ b/user/src/main/java/com/logistcshub/user/infrastructure/common/AuditEntity.java
@@ -1,0 +1,51 @@
+package com.logistcshub.user.infrastructure.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+public class AuditEntity {
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @CreatedBy
+    @Column(name = "created_by", updatable = false)
+    private String createdBy;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @LastModifiedBy
+    @Column(name = "updated_by")
+    private String updatedBy;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @Column(name = "deleted_by")
+    private String deletedBy;
+
+    @Column(name = "is_delete")
+    private Boolean isDelete = false;
+
+    // 논리적 삭제 메서드
+    public void delete(String email) {
+        deletedAt = LocalDateTime.now();
+        deletedBy = email;
+        isDelete = true;
+    }
+
+}

--- a/user/src/main/java/com/logistcshub/user/infrastructure/common/AuditEntity.java
+++ b/user/src/main/java/com/logistcshub/user/infrastructure/common/AuditEntity.java
@@ -41,7 +41,7 @@ public class AuditEntity {
     @Column(name = "is_delete")
     private Boolean isDelete = false;
 
-    // 논리적 삭제 메서드
+    // Soft Delete
     public void delete(String email) {
         deletedAt = LocalDateTime.now();
         deletedBy = email;

--- a/user/src/main/java/com/logistcshub/user/infrastructure/common/SearchResponse.java
+++ b/user/src/main/java/com/logistcshub/user/infrastructure/common/SearchResponse.java
@@ -1,4 +1,6 @@
-package com.logistcshub.user.application.dtos;
+package com.logistcshub.user.infrastructure.common;
+
+import com.logistcshub.user.application.dtos.UserDto;
 
 import java.io.Serializable;
 import java.util.List;

--- a/user/src/main/java/com/logistcshub/user/infrastructure/configuration/WebSecurity.java
+++ b/user/src/main/java/com/logistcshub/user/infrastructure/configuration/WebSecurity.java
@@ -16,8 +16,8 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
-@EnableMethodSecurity
 @RequiredArgsConstructor
+@EnableMethodSecurity(securedEnabled = true, prePostEnabled = true)
 public class WebSecurity {
 
     private final CustomAuthPreFilter customAuthPreFilter;

--- a/user/src/main/java/com/logistcshub/user/infrastructure/repository/UserRepositoryCustom.java
+++ b/user/src/main/java/com/logistcshub/user/infrastructure/repository/UserRepositoryCustom.java
@@ -1,6 +1,6 @@
 package com.logistcshub.user.infrastructure.repository;
 
-import com.logistcshub.user.application.dtos.SearchResponse;
+import com.logistcshub.user.infrastructure.common.SearchResponse;
 import com.logistcshub.user.presentation.request.SearchRequest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/user/src/main/java/com/logistcshub/user/infrastructure/repository/UserRepositoryImpl.java
+++ b/user/src/main/java/com/logistcshub/user/infrastructure/repository/UserRepositoryImpl.java
@@ -1,7 +1,7 @@
 package com.logistcshub.user.infrastructure.repository;
 
 import com.logistcshub.user.application.dtos.QUserDto;
-import com.logistcshub.user.application.dtos.SearchResponse;
+import com.logistcshub.user.infrastructure.common.SearchResponse;
 import com.logistcshub.user.application.dtos.UserDto;
 import com.logistcshub.user.domain.model.UserRoleEnum;
 import com.logistcshub.user.presentation.request.SearchRequest;
@@ -15,7 +15,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 

--- a/user/src/main/java/com/logistcshub/user/presentation/controller/DeliveryManagerController.java
+++ b/user/src/main/java/com/logistcshub/user/presentation/controller/DeliveryManagerController.java
@@ -1,0 +1,33 @@
+//package com.logistcshub.user.presentation.controller;
+//
+//import com.logistcshub.user.application.dtos.DeliveryManagerDto;
+//import com.logistcshub.user.application.dtos.HubDto;
+//import com.logistcshub.user.application.security.UserDetailsImpl;
+//import com.logistcshub.user.application.service.DeliveryManagerService;
+//import com.logistcshub.user.domain.model.UserRoleEnum;
+//import com.logistcshub.user.infrastructure.common.ApiResponse;
+//import com.logistcshub.user.infrastructure.common.MessageType;
+//import com.logistcshub.user.presentation.request.DeliveryManagerCreate;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.security.access.prepost.PreAuthorize;
+//import org.springframework.security.core.annotation.AuthenticationPrincipal;
+//import org.springframework.web.bind.annotation.*;
+//
+//@RestController
+//@RequestMapping("/api/delivery-managers")
+//@RequiredArgsConstructor
+//public class DeliveryManagerController {
+//
+//    private final DeliveryManagerService deliveryManagerService;
+//
+//    @PostMapping
+//    @PreAuthorize("hasAnyAuthority('MASTER', 'HUB_MANAGER')")
+//    public ApiResponse<DeliveryManagerDto> create(@AuthenticationPrincipal UserDetailsImpl userDetails,
+//                                                  @RequestBody DeliveryManagerCreate createRequest) {
+//
+//        return ApiResponse.<DeliveryManagerDto>builder()
+//                .messageType(MessageType.CREATE)
+//                .data(deliveryManagerService.create(userDetails, createRequest))
+//                .build();
+//    }
+//}

--- a/user/src/main/java/com/logistcshub/user/presentation/controller/HubManagerController.java
+++ b/user/src/main/java/com/logistcshub/user/presentation/controller/HubManagerController.java
@@ -1,0 +1,32 @@
+package com.logistcshub.user.presentation.controller;
+
+import com.logistcshub.user.application.security.UserDetailsImpl;
+import com.logistcshub.user.application.service.HubManagerService;
+import com.logistcshub.user.infrastructure.common.ApiResponse;
+import com.logistcshub.user.infrastructure.common.MessageType;
+import com.logistcshub.user.presentation.request.HubManagerRequest;
+import com.logistcshub.user.presentation.response.HubManagerResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/hub-manager")
+@RequiredArgsConstructor
+public class HubManagerController {
+
+    private final HubManagerService hubManagerService;
+
+    // 허브 매니저 등록
+    @PostMapping
+    public ApiResponse<HubManagerResponse> createHubManager(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                            @RequestBody HubManagerRequest hubManagerRequest) {
+        return ApiResponse.<HubManagerResponse>builder()
+                .messageType(MessageType.CREATE)
+                .data(hubManagerService.createHubManager(userDetails, hubManagerRequest))
+                .build();
+    }
+}

--- a/user/src/main/java/com/logistcshub/user/presentation/controller/HubManagerController.java
+++ b/user/src/main/java/com/logistcshub/user/presentation/controller/HubManagerController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/hub-manager")
+@RequestMapping("/api/hub-managers")
 @RequiredArgsConstructor
 public class HubManagerController {
 

--- a/user/src/main/java/com/logistcshub/user/presentation/controller/UserController.java
+++ b/user/src/main/java/com/logistcshub/user/presentation/controller/UserController.java
@@ -1,18 +1,15 @@
 package com.logistcshub.user.presentation.controller;
 
 import com.logistcshub.user.application.dtos.MyInfoDto;
-import com.logistcshub.user.application.dtos.SearchResponse;
+import com.logistcshub.user.infrastructure.common.SearchResponse;
 import com.logistcshub.user.application.dtos.UserDto;
 import com.logistcshub.user.application.security.UserDetailsImpl;
 import com.logistcshub.user.application.service.UserService;
 import com.logistcshub.user.domain.model.UserRoleEnum;
 import com.logistcshub.user.infrastructure.common.ApiResponse;
 import com.logistcshub.user.infrastructure.common.MessageType;
-import com.logistcshub.user.infrastructure.common.PageResponse;
-import com.logistcshub.user.infrastructure.common.SearchParameter;
 import com.logistcshub.user.presentation.request.SearchRequest;
 import com.logistcshub.user.presentation.request.UserUpdateRequest;
-import io.micrometer.core.instrument.search.Search;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/user/src/main/java/com/logistcshub/user/presentation/controller/UserController.java
+++ b/user/src/main/java/com/logistcshub/user/presentation/controller/UserController.java
@@ -27,6 +27,7 @@ public class UserController {
 
     private final UserService userService;
 
+    // 내 정보 조회
     @GetMapping("/user/{id}")
     public ApiResponse<MyInfoDto> getMyInfo(@PathVariable Long id) {
         return ApiResponse.<MyInfoDto>builder()
@@ -35,7 +36,8 @@ public class UserController {
                 .build();
     }
 
-    @GetMapping("/users")
+    // 유저 전체 조회 (MASTER)
+    @GetMapping("/admin/users")
     public ApiResponse<Page<SearchResponse>> getUserList(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @PageableDefault Pageable pageable,
@@ -51,7 +53,17 @@ public class UserController {
                 .build();
     }
 
-    @PatchMapping("/user/{id}")
+    // 유저 상세 조회 (MASTER)
+    @GetMapping("/admin/user/{id}")
+    public ApiResponse<UserDto> get(@PathVariable Long id) {
+        return ApiResponse.<UserDto>builder()
+                .messageType(MessageType.RETRIEVE)
+                .data(userService.get(id))
+                .build();
+    }
+
+    // 유저 권한 수정 (MASTER)
+    @PatchMapping("/admin/user/{id}")
     public ApiResponse<UserDto> update(@PathVariable Long id, @RequestBody UserUpdateRequest userUpdateRequest) {
         return ApiResponse.<UserDto>builder()
                 .messageType(MessageType.UPDATE)
@@ -59,12 +71,12 @@ public class UserController {
                 .build();
     }
 
-    @DeleteMapping("/user/{id}")
+    // 유저 탈퇴 (MASTER)
+    @DeleteMapping("/admin/user/{id}")
     public ApiResponse<String> delete(@PathVariable Long id) {
         return ApiResponse.<String>builder()
                 .messageType(MessageType.DELETE)
                 .data(userService.delete(id))
                 .build();
     }
-
 }

--- a/user/src/main/java/com/logistcshub/user/presentation/controller/UserController.java
+++ b/user/src/main/java/com/logistcshub/user/presentation/controller/UserController.java
@@ -17,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -29,6 +30,7 @@ public class UserController {
 
     // 내 정보 조회
     @GetMapping("/user/{id}")
+    @PreAuthorize("isAuthenticated() and hasRole('MASTER') or hasRole('COMPANY_MANAGER') or hasRole('DELIVERY_MANAGER') or hasRole('HUB_MANAGER')")
     public ApiResponse<MyInfoDto> getMyInfo(@PathVariable Long id) {
         return ApiResponse.<MyInfoDto>builder()
                 .messageType(MessageType.RETRIEVE)
@@ -38,6 +40,7 @@ public class UserController {
 
     // 유저 전체 조회 (MASTER)
     @GetMapping("/admin/users")
+    @PreAuthorize("isAuthenticated() and hasRole('MASTER')")
     public ApiResponse<Page<SearchResponse>> getUserList(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @PageableDefault Pageable pageable,
@@ -55,6 +58,7 @@ public class UserController {
 
     // 유저 상세 조회 (MASTER)
     @GetMapping("/admin/user/{id}")
+    @PreAuthorize("isAuthenticated() and hasRole('MASTER')")
     public ApiResponse<UserDto> get(@PathVariable Long id) {
         return ApiResponse.<UserDto>builder()
                 .messageType(MessageType.RETRIEVE)
@@ -64,6 +68,7 @@ public class UserController {
 
     // 유저 권한 수정 (MASTER)
     @PatchMapping("/admin/user/{id}")
+    @PreAuthorize("isAuthenticated() and hasRole('MASTER')")
     public ApiResponse<UserDto> update(@PathVariable Long id, @RequestBody UserUpdateRequest userUpdateRequest) {
         return ApiResponse.<UserDto>builder()
                 .messageType(MessageType.UPDATE)
@@ -73,6 +78,7 @@ public class UserController {
 
     // 유저 탈퇴 (MASTER)
     @DeleteMapping("/admin/user/{id}")
+    @PreAuthorize("isAuthenticated() and hasRole('MASTER')")
     public ApiResponse<String> delete(@PathVariable Long id) {
         return ApiResponse.<String>builder()
                 .messageType(MessageType.DELETE)

--- a/user/src/main/java/com/logistcshub/user/presentation/controller/UserController.java
+++ b/user/src/main/java/com/logistcshub/user/presentation/controller/UserController.java
@@ -19,7 +19,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api")
+@RequestMapping("/api/users")
 @RequiredArgsConstructor
 public class UserController {
 
@@ -36,7 +36,7 @@ public class UserController {
     }
 
     // 유저 전체 조회 (MASTER)
-    @GetMapping("/admin/users")
+    @GetMapping
     @PreAuthorize("hasAuthority('MASTER')")
     public ApiResponse<Page<SearchResponse>> getUserList(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
@@ -54,7 +54,7 @@ public class UserController {
     }
 
     // 유저 상세 조회 (MASTER)
-    @GetMapping("/admin/user/{id}")
+    @GetMapping("/{id}")
     @PreAuthorize("hasAuthority('MASTER')")
     public ApiResponse<UserDto> get(@PathVariable Long id) {
         return ApiResponse.<UserDto>builder()
@@ -64,7 +64,7 @@ public class UserController {
     }
 
     // 유저 권한 수정 (MASTER)
-    @PatchMapping("/admin/user/{id}")
+    @PatchMapping("/{id}")
     @PreAuthorize("hasAuthority('MASTER')")
     public ApiResponse<UserDto> update(@PathVariable Long id, @RequestBody UserUpdateRequest userUpdateRequest) {
         return ApiResponse.<UserDto>builder()
@@ -74,7 +74,7 @@ public class UserController {
     }
 
     // 유저 탈퇴 (MASTER)
-    @DeleteMapping("/admin/user/{id}")
+    @DeleteMapping("/{id}")
     @PreAuthorize("hasAuthority('MASTER')")
     public ApiResponse<String> delete(@PathVariable Long id) {
         return ApiResponse.<String>builder()

--- a/user/src/main/java/com/logistcshub/user/presentation/controller/UserController.java
+++ b/user/src/main/java/com/logistcshub/user/presentation/controller/UserController.java
@@ -8,12 +8,15 @@ import com.logistcshub.user.application.service.UserService;
 import com.logistcshub.user.domain.model.UserRoleEnum;
 import com.logistcshub.user.infrastructure.common.ApiResponse;
 import com.logistcshub.user.infrastructure.common.MessageType;
+import com.logistcshub.user.presentation.request.HubManagerRequest;
 import com.logistcshub.user.presentation.request.SearchRequest;
 import com.logistcshub.user.presentation.request.UserUpdateRequest;
+import com.logistcshub.user.presentation.response.HubManagerResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -82,4 +85,5 @@ public class UserController {
                 .data(userService.delete(id))
                 .build();
     }
+
 }

--- a/user/src/main/java/com/logistcshub/user/presentation/controller/UserController.java
+++ b/user/src/main/java/com/logistcshub/user/presentation/controller/UserController.java
@@ -30,7 +30,7 @@ public class UserController {
 
     // 내 정보 조회
     @GetMapping("/user/{id}")
-    @PreAuthorize("isAuthenticated() and hasRole('MASTER') or hasRole('COMPANY_MANAGER') or hasRole('DELIVERY_MANAGER') or hasRole('HUB_MANAGER')")
+    @PreAuthorize("hasAnyAuthority('MASTER', 'HUB_MANAGER', 'DELIVERY_MANAGER', 'COMPANY_MAMAGER')")
     public ApiResponse<MyInfoDto> getMyInfo(@PathVariable Long id) {
         return ApiResponse.<MyInfoDto>builder()
                 .messageType(MessageType.RETRIEVE)
@@ -40,7 +40,7 @@ public class UserController {
 
     // 유저 전체 조회 (MASTER)
     @GetMapping("/admin/users")
-    @PreAuthorize("isAuthenticated() and hasRole('MASTER')")
+    @PreAuthorize("hasAuthority('MASTER')")
     public ApiResponse<Page<SearchResponse>> getUserList(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @PageableDefault Pageable pageable,
@@ -58,7 +58,7 @@ public class UserController {
 
     // 유저 상세 조회 (MASTER)
     @GetMapping("/admin/user/{id}")
-    @PreAuthorize("isAuthenticated() and hasRole('MASTER')")
+    @PreAuthorize("hasAuthority('MASTER')")
     public ApiResponse<UserDto> get(@PathVariable Long id) {
         return ApiResponse.<UserDto>builder()
                 .messageType(MessageType.RETRIEVE)
@@ -68,7 +68,7 @@ public class UserController {
 
     // 유저 권한 수정 (MASTER)
     @PatchMapping("/admin/user/{id}")
-    @PreAuthorize("isAuthenticated() and hasRole('MASTER')")
+    @PreAuthorize("hasAuthority('MASTER')")
     public ApiResponse<UserDto> update(@PathVariable Long id, @RequestBody UserUpdateRequest userUpdateRequest) {
         return ApiResponse.<UserDto>builder()
                 .messageType(MessageType.UPDATE)
@@ -78,7 +78,7 @@ public class UserController {
 
     // 유저 탈퇴 (MASTER)
     @DeleteMapping("/admin/user/{id}")
-    @PreAuthorize("isAuthenticated() and hasRole('MASTER')")
+    @PreAuthorize("hasAuthority('MASTER')")
     public ApiResponse<String> delete(@PathVariable Long id) {
         return ApiResponse.<String>builder()
                 .messageType(MessageType.DELETE)

--- a/user/src/main/java/com/logistcshub/user/presentation/request/DeliveryManagerCreate.java
+++ b/user/src/main/java/com/logistcshub/user/presentation/request/DeliveryManagerCreate.java
@@ -1,0 +1,12 @@
+package com.logistcshub.user.presentation.request;
+
+import com.logistcshub.user.domain.model.DeliveryManagerType;
+import com.logistcshub.user.domain.model.DeliveryStatus;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+public record DeliveryManagerCreate(Long userId,
+                                    UUID hubId,
+                                    DeliveryManagerType deliveryManagerType) implements Serializable {
+}

--- a/user/src/main/java/com/logistcshub/user/presentation/request/HubManagerRequest.java
+++ b/user/src/main/java/com/logistcshub/user/presentation/request/HubManagerRequest.java
@@ -1,0 +1,6 @@
+package com.logistcshub.user.presentation.request;
+
+import java.util.UUID;
+
+public record HubManagerRequest(Long userId, UUID hubId) {
+}

--- a/user/src/main/java/com/logistcshub/user/presentation/request/HubRequest.java
+++ b/user/src/main/java/com/logistcshub/user/presentation/request/HubRequest.java
@@ -1,8 +1,0 @@
-package com.logistcshub.user.presentation.request;
-
-import com.logistcshub.user.application.dtos.HubDto;
-
-import java.io.Serializable;
-
-public record HubRequest(int code, String message, com.logistcshub.user.application.dtos.HubDto HubDto) implements Serializable {
-}

--- a/user/src/main/java/com/logistcshub/user/presentation/request/HubRequest.java
+++ b/user/src/main/java/com/logistcshub/user/presentation/request/HubRequest.java
@@ -1,0 +1,8 @@
+package com.logistcshub.user.presentation.request;
+
+import com.logistcshub.user.application.dtos.HubDto;
+
+import java.io.Serializable;
+
+public record HubRequest(int code, String message, com.logistcshub.user.application.dtos.HubDto HubDto) implements Serializable {
+}

--- a/user/src/main/java/com/logistcshub/user/presentation/response/HubManagerResponse.java
+++ b/user/src/main/java/com/logistcshub/user/presentation/response/HubManagerResponse.java
@@ -1,0 +1,16 @@
+package com.logistcshub.user.presentation.response;
+
+import com.logistcshub.user.domain.model.HubManager;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+public record HubManagerResponse(Long userId, UUID hubId) implements Serializable {
+
+    public static HubManagerResponse of(HubManager hubManager) {
+        return new HubManagerResponse(
+                hubManager.getUser().getId(),
+                hubManager.getHubId()
+        );
+    }
+}

--- a/user/test.http
+++ b/user/test.http
@@ -50,3 +50,10 @@ Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwicm9sZSI6Ik1BU1RFUiIsI
 Content-Type: application/json
 X-User-Id: 1
 X-User-Role: MASTER
+
+### 허브 매니저 생성
+POST http://localhost:19093/api/hub-manager
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwicm9sZSI6Ik1BU1RFUiIsImlzcyI6InVzZXItc2VydmljZSIsImlhdCI6MTczNDAxOTAzOSwiZXhwIjoxNzM0MDE5Mzk5fQ.0S2Zk1Z9qwcOFrIZnnZ_V5nL1FhYu-5P7vCHSUhlnRNeFb2_qCzVq_qcWmMuIzzC34Mz7PxOaF-ggMp_2Nzqng
+Content-Type: application/json
+X-User-Id: 1
+X-User-Role: MASTER


### PR DESCRIPTION
## #️⃣연관된 이슈

> #30

## 📝작업 내용

> User
- 유저 상세 조회 추가했습니다

> HubManager
- 배송담당자 API 호출시 담당 허브 관리자만 담당 허브에 접근하도록 하기위해 
각 허브 담당 관리자를 담아 놓는 중간엔티티를 생성했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

- FeingClient 관련해서 생각보다 작업이 오래 걸렸습니다...!
- 배송담당자 CRUD는 작업 중입니다.
