### PR TITLE
Feat: hub-transfer 등록 기능 추가

### DIFF
--- a/hub/src/main/java/com/logistcshub/hub/common/config/KakaoRoadApiConfig.java
+++ b/hub/src/main/java/com/logistcshub/hub/common/config/KakaoRoadApiConfig.java
@@ -1,0 +1,15 @@
+package com.logistcshub.hub.common.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "kakaoroad")
+public class KakaoRoadApiConfig {
+    private String adminKey;
+    private String roadUrl;
+}

--- a/hub/src/main/java/com/logistcshub/hub/common/domain/model/dtos/KakaoResponse.java
+++ b/hub/src/main/java/com/logistcshub/hub/common/domain/model/dtos/KakaoResponse.java
@@ -1,0 +1,62 @@
+package com.logistcshub.hub.common.domain.model.dtos;
+
+import java.util.List;
+
+public record KakaoResponse(
+        String trans_id,
+        List<Route> routes
+) {
+    public record Route(
+            int result_code,
+            String result_msg,
+            Summary summary,
+            List<Section> sections
+    ) {
+        public record Summary(
+                Origin origin,
+                Destination destination,
+                List<Waypoint> waypoints,
+                String priority,
+                Bound bound,
+                Fare fare,
+                int distance,
+                int duration
+        ) {
+            public record Origin(
+                    String name,
+                    double x,
+                    double y
+            ) {}
+
+            public record Destination(
+                    String name,
+                    double x,
+                    double y
+            ) {}
+
+            public record Waypoint(
+                    String name,
+                    double x,
+                    double y
+            ) {}
+
+            public record Bound(
+                    double min_x,
+                    double min_y,
+                    double max_x,
+                    double max_y
+            ) {}
+
+            public record Fare(
+                    int taxi,
+                    int toll
+            ) {}
+        }
+
+        public record Section(
+                int distance,
+                int duration
+        ) {}
+    }
+}
+

--- a/hub/src/main/java/com/logistcshub/hub/common/domain/model/dtos/KakaoRoadRequestDto.java
+++ b/hub/src/main/java/com/logistcshub/hub/common/domain/model/dtos/KakaoRoadRequestDto.java
@@ -1,0 +1,21 @@
+package com.logistcshub.hub.common.domain.model.dtos;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+
+public record KakaoRoadRequestDto (
+        Coordinate origin,
+        Coordinate destination,
+        boolean summary
+) {
+
+    @AllArgsConstructor
+    public static class Coordinate {
+        double x;
+        double y;
+    }
+
+    public KakaoRoadRequestDto(Coordinate origin, Coordinate destination) {
+        this(origin, destination, false);
+    }
+}

--- a/hub/src/main/java/com/logistcshub/hub/common/domain/model/dtos/KakaoRoadResponseDto.java
+++ b/hub/src/main/java/com/logistcshub/hub/common/domain/model/dtos/KakaoRoadResponseDto.java
@@ -1,0 +1,15 @@
+package com.logistcshub.hub.common.domain.model.dtos;
+
+import com.logistcshub.hub.common.domain.model.dtos.KakaoResponse.Route.Summary;
+
+public record KakaoRoadResponseDto (
+        Integer distance,
+        Integer duration
+) {
+    public static KakaoRoadResponseDto of(Summary summary) {
+        return new KakaoRoadResponseDto(
+                summary.distance(),
+                summary.duration()
+        );
+    }
+}

--- a/hub/src/main/java/com/logistcshub/hub/common/domain/model/type/ResponseMessage.java
+++ b/hub/src/main/java/com/logistcshub/hub/common/domain/model/type/ResponseMessage.java
@@ -19,6 +19,8 @@ public enum ResponseMessage {
     SUCCESS_DELETE_HUB(HttpStatus.OK, "허브 삭제에 성공했습니다."),
     SUCCESS_GET_HUB(HttpStatus.OK, "허브 상세 조회에 성공했습니다."),
 
+    SUCCESS_CREATE_HUB_TRANSFER(HttpStatus.OK, "허브 to 허브 생성에 성공했습니다."),
+
     ;
     private final HttpStatus status;
     private final String message;

--- a/hub/src/main/java/com/logistcshub/hub/common/exception/application/type/ErrorCode.java
+++ b/hub/src/main/java/com/logistcshub/hub/common/exception/application/type/ErrorCode.java
@@ -20,8 +20,14 @@ public enum ErrorCode {
     KAKAO_MAP_SERVER_ERROR(HttpStatus.BAD_GATEWAY, "카카오 맵 API 서버 에러입니다."),
     KAKAO_MAP_TIME_OUT(HttpStatus.GATEWAY_TIMEOUT, "카카오 맵 API TIME OUT"),
 
+    KAKAO_ROAD_CLIENT_ERROR(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    KAKAO_ROAD_SERVER_ERROR(HttpStatus.BAD_GATEWAY, "카카오 길찾기 API 서버 에러입니다."),
+    KAKAO_ROAD_TIME_OUT(HttpStatus.GATEWAY_TIMEOUT, "카카오 길찾기 API TIME OUT"),
+    KAKAO_ROAD_NOT_FOUND(HttpStatus.NOT_FOUND, "카카오 길찾기에 실패했습니다."),
+
     HUB_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 허브를 찾을 수 없습니다."),
     ALREADY_EXISTS_HUB(HttpStatus.BAD_REQUEST, "이미 존재하는 허브입니다."),
+    ALREADY_EXISTS_HUB_TRANSFER(HttpStatus.BAD_REQUEST, "이미 존재하는 경로입니다. 시간 혹은 거리를 업데이트 하시고 싶으시면 PUT 요청해주세요."),
 
 
     ;

--- a/hub/src/main/java/com/logistcshub/hub/hub/application/config/AddHubListInserter.java
+++ b/hub/src/main/java/com/logistcshub/hub/hub/application/config/AddHubListInserter.java
@@ -44,19 +44,19 @@ public class AddHubListInserter {
         Long userId = 1L;
         String role = "MASTER";
 
-        for(AddHubRequestDto hub : hubs) {
-            try {
-                hubService.addHub(userId, role, hub);
-            } catch (RestApiException e) {
-                log.info("exception : {} : {}", hub.name(), e.getErrorCode().getDescription());
-            }
-            try {
-                Thread.sleep(500); // 500 milliseconds
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt(); // 인터럽트 상태 복구
-                System.err.println("Thread was interrupted during sleep.");
-            }
-        }
+//        for(AddHubRequestDto hub : hubs) {
+//            try {
+//                hubService.addHub(userId, role, hub);
+//            } catch (RestApiException e) {
+//                log.info("exception : {} : {}", hub.name(), e.getErrorCode().getDescription());
+//            }
+//            try {
+//                Thread.sleep(500); // 500 milliseconds
+//            } catch (InterruptedException e) {
+//                Thread.currentThread().interrupt(); // 인터럽트 상태 복구
+//                System.err.println("Thread was interrupted during sleep.");
+//            }
+//        }
 
     }
 }

--- a/hub/src/main/java/com/logistcshub/hub/hub/application/service/HubService.java
+++ b/hub/src/main/java/com/logistcshub/hub/hub/application/service/HubService.java
@@ -64,7 +64,7 @@ public class HubService {
         Area area = findAreaToAddress(addresses);
         String detailAddress = getDetailAddress(addresses);
 
-        if(hubRepository.existsByAreaAndAddress(area, detailAddress)) {
+        if(hubRepository.existsByAreaAndAddressAndDeletedFalse(area, detailAddress)) {
             throw new RestApiException(ALREADY_EXISTS_HUB);
         }
 
@@ -77,7 +77,7 @@ public class HubService {
 
     @Transactional
     public UpdateHubResponseDto updateHub(UUID id, Long userId, String role, UpdateHubRequestDto request) {
-        Hub hub = hubRepository.findByIdWithArea(id).orElseThrow(() ->
+        Hub hub = hubRepository.findByIdWithAreaAndDeletedFalse(id).orElseThrow(() ->
                 new RestApiException(HUB_NOT_FOUND));
         String[] addresses = request.address().split(" ");
 
@@ -96,7 +96,7 @@ public class HubService {
 
     @Transactional
     public DeleteHubResponseDto deleteHub(UUID id, Long userId, String role) {
-        Hub hub = hubRepository.findById(id).orElseThrow(() ->
+        Hub hub = hubRepository.findByIdAndDeletedFalse(id).orElseThrow(() ->
                 new RestApiException(HUB_NOT_FOUND));
 
         hub.delete(userId);
@@ -105,7 +105,7 @@ public class HubService {
     }
 
     public HubResponseDto getHub(UUID id, Long userId, String role) {
-        return HubResponseDto.of(hubRepository.findByIdWithArea(id).orElseThrow(() ->
+        return HubResponseDto.of(hubRepository.findByIdWithAreaAndDeletedFalse(id).orElseThrow(() ->
                 new RestApiException(HUB_NOT_FOUND)));
 
     }

--- a/hub/src/main/java/com/logistcshub/hub/hub/domain/repository/HubRepository.java
+++ b/hub/src/main/java/com/logistcshub/hub/hub/domain/repository/HubRepository.java
@@ -9,9 +9,9 @@ public interface HubRepository {
 
     Hub save(Hub hub);
 
-    Optional<Hub> findById(UUID id);
+    Optional<Hub> findByIdAndDeletedFalse(UUID id);
 
-    Optional<Hub> findByIdWithArea(UUID id);
+    Optional<Hub> findByIdWithAreaAndDeletedFalse(UUID id);
 
-    boolean existsByAreaAndAddress(Area area, String address);
+    boolean existsByAreaAndAddressAndDeletedFalse(Area area, String address);
 }

--- a/hub/src/main/java/com/logistcshub/hub/hub/infrastructure/HubRepositoryImpl.java
+++ b/hub/src/main/java/com/logistcshub/hub/hub/infrastructure/HubRepositoryImpl.java
@@ -20,17 +20,17 @@ public class HubRepositoryImpl implements HubRepository {
     }
 
     @Override
-    public Optional<Hub> findById(UUID id) {
-        return jpaHubRepository.findById(id);
+    public Optional<Hub> findByIdAndDeletedFalse(UUID id) {
+        return jpaHubRepository.findByIdAndDeletedFalse(id);
     }
 
     @Override
-    public Optional<Hub> findByIdWithArea(UUID id) {
-        return jpaHubRepository.findByIdWithArea(id);
+    public Optional<Hub> findByIdWithAreaAndDeletedFalse(UUID id) {
+        return jpaHubRepository.findByIdWithAreaAndDeletedFalse(id);
     }
 
     @Override
-    public boolean existsByAreaAndAddress(Area area, String address) {
-        return jpaHubRepository.existsByAreaAndAddress(area, address);
+    public boolean existsByAreaAndAddressAndDeletedFalse(Area area, String address) {
+        return jpaHubRepository.existsByAreaAndAddressAndDeletedFalse(area, address);
     }
 }

--- a/hub/src/main/java/com/logistcshub/hub/hub/infrastructure/JpaHubRepository.java
+++ b/hub/src/main/java/com/logistcshub/hub/hub/infrastructure/JpaHubRepository.java
@@ -11,7 +11,9 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface JpaHubRepository extends JpaRepository<Hub, UUID> {
     @Query("select h from Hub h join fetch h.area where h.id = :id and h.isDeleted is false")
-    Optional<Hub> findByIdWithArea(UUID id);
+    Optional<Hub> findByIdWithAreaAndDeletedFalse(UUID id);
 
-    boolean existsByAreaAndAddress(Area area, String address);
+    boolean existsByAreaAndAddressAndDeletedFalse(Area area, String address);
+
+    Optional<Hub> findByIdAndDeletedFalse(UUID id);
 }

--- a/hub/src/main/java/com/logistcshub/hub/hub_transfer/application/dtos/AddHubTransferResponseDto.java
+++ b/hub/src/main/java/com/logistcshub/hub/hub_transfer/application/dtos/AddHubTransferResponseDto.java
@@ -1,0 +1,40 @@
+package com.logistcshub.hub.hub_transfer.application.dtos;
+
+import com.logistcshub.hub.hub.domain.mode.Hub;
+import com.logistcshub.hub.hub_transfer.domain.model.HubTransfer;
+import java.util.UUID;
+
+public record AddHubTransferResponseDto(
+        UUID id,
+        UUID startHubId,
+        String startHubName,
+        UUID endHubId,
+        String endHubName,
+        Integer time_taken,
+        Integer distance
+) {
+
+    public static AddHubTransferResponseDto of(HubTransfer transfer){
+        return new AddHubTransferResponseDto(
+                transfer.getId(),
+                transfer.getStartHub().getId(),
+                transfer.getStartHub().getName(),
+                transfer.getEndHub().getId(),
+                transfer.getEndHub().getName(),
+                transfer.getTimeTaken(),
+                transfer.getDistance()
+        );
+    }
+
+    public static AddHubTransferResponseDto of(HubTransfer transfer, Hub startHub, Hub endHub){
+        return new AddHubTransferResponseDto(
+                transfer.getId(),
+                startHub.getId(),
+                startHub.getName(),
+                endHub.getId(),
+                endHub.getName(),
+                transfer.getTimeTaken(),
+                transfer.getDistance()
+        );
+    }
+}

--- a/hub/src/main/java/com/logistcshub/hub/hub_transfer/application/service/HubTransferService.java
+++ b/hub/src/main/java/com/logistcshub/hub/hub_transfer/application/service/HubTransferService.java
@@ -1,13 +1,132 @@
 package com.logistcshub.hub.hub_transfer.application.service;
 
+import static com.logistcshub.hub.common.exception.application.type.ErrorCode.ALREADY_EXISTS_HUB_TRANSFER;
+import static com.logistcshub.hub.common.exception.application.type.ErrorCode.HUB_NOT_FOUND;
+import static com.logistcshub.hub.common.exception.application.type.ErrorCode.INTERNAL_SERVER_ERROR;
+import static com.logistcshub.hub.common.exception.application.type.ErrorCode.KAKAO_ROAD_CLIENT_ERROR;
+import static com.logistcshub.hub.common.exception.application.type.ErrorCode.KAKAO_ROAD_SERVER_ERROR;
+import static com.logistcshub.hub.common.exception.application.type.ErrorCode.KAKAO_ROAD_TIME_OUT;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.logistcshub.hub.common.config.KakaoRoadApiConfig;
+import com.logistcshub.hub.common.domain.model.dtos.KakaoResponse;
+import com.logistcshub.hub.common.domain.model.dtos.KakaoResponse.Route.Summary;
+import com.logistcshub.hub.common.domain.model.dtos.KakaoRoadResponseDto;
+import com.logistcshub.hub.common.exception.RestApiException;
+import com.logistcshub.hub.hub.domain.mode.Hub;
+import com.logistcshub.hub.hub.domain.repository.HubRepository;
+import com.logistcshub.hub.hub_transfer.application.dtos.AddHubTransferResponseDto;
+import com.logistcshub.hub.hub_transfer.domain.model.HubTransfer;
 import com.logistcshub.hub.hub_transfer.domain.repository.HubTransferRepository;
+import com.logistcshub.hub.hub_transfer.presentation.request.AddHubTransferRequestDto;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class HubTransferService {
     private final HubTransferRepository hubTransferRepository;
+    private final HubRepository hubRepository;
+    private final RestTemplate restTemplate;
+    private final KakaoRoadApiConfig kakaoRoadApiConfig;
+
+    @Transactional
+    public List<AddHubTransferResponseDto> addHubTransfer(AddHubTransferRequestDto request, String role, Long userId) {
+
+        Hub startHub = hubRepository.findByIdAndDeletedFalse(request.startHubId()).orElseThrow(() ->
+                new RestApiException(HUB_NOT_FOUND));
+
+        Hub endHub = hubRepository.findByIdAndDeletedFalse(request.endHubId()).orElseThrow(() ->
+                new RestApiException(HUB_NOT_FOUND));
+
+        if(hubTransferRepository.existsByStartHubAndEndHubAndDeletedFalse(startHub, endHub)) {
+            throw new RestApiException(ALREADY_EXISTS_HUB_TRANSFER);
+        }
+
+        HubTransfer startToEnd = extracted(startHub, endHub);
+        HubTransfer endToStart = extracted(endHub, startHub);
+
+        startToEnd = hubTransferRepository.save(startToEnd);
+        endToStart = hubTransferRepository.save(endToStart);
+
+        AddHubTransferResponseDto startToEndDto = AddHubTransferResponseDto.of(startToEnd, startHub, endHub);
+        AddHubTransferResponseDto endToStartDto = AddHubTransferResponseDto.of(endToStart, endHub, startHub);
+
+        List<AddHubTransferResponseDto> responseDtos = new ArrayList<>();
+        responseDtos.add(startToEndDto);
+        responseDtos.add(endToStartDto);
+
+        return responseDtos;
+    }
+
+    private HubTransfer extracted(Hub startHub, Hub endHub) {
+        try {
+            HttpEntity<Map<String, String>> requestEntity = new HttpEntity<>(this.getHeader());
+
+            UriComponents uriComponents = UriComponentsBuilder.fromUriString(kakaoRoadApiConfig.getRoadUrl())
+                    .queryParam("origin", startHub.getLng() + "," + startHub.getLat())
+                    .queryParam("destination", endHub.getLng() + "," + endHub.getLat())
+                    .queryParam("summary", true)
+                    .encode(StandardCharsets.UTF_8) // UTF-8로 인코딩
+                    .build();
+
+            URI targetUrl = uriComponents.toUri();
+            ResponseEntity<Map> responseEntity = restTemplate.exchange(targetUrl, HttpMethod.GET, requestEntity,
+                    Map.class);
+
+            ObjectMapper mapper = new ObjectMapper();
+            KakaoResponse kakaoResponse = mapper.convertValue(responseEntity.getBody(), KakaoResponse.class);
+
+            Summary summary = kakaoResponse.routes().get(0).summary();
+            System.out.println(summary.distance());
+            System.out.println(summary.duration());
+            KakaoRoadResponseDto kakaoMapResponse = KakaoRoadResponseDto.of(summary);
+
+            return HubTransfer.builder()
+                    .startHub(startHub)
+                    .endHub(endHub)
+                    .distance(kakaoMapResponse.distance()/1000)
+                    .timeTaken(kakaoMapResponse.duration()/60)
+                    .build();
+        } catch (HttpClientErrorException e) {
+            // 클라이언트 오류 (4xx)
+            throw new RestApiException(KAKAO_ROAD_CLIENT_ERROR);
+        } catch (HttpServerErrorException e) {
+            // 서버 오류 (5xx)
+            throw new RestApiException(KAKAO_ROAD_SERVER_ERROR);
+        } catch (RestClientException e) {
+            // 일반적인 RestTemplate 오류 처리
+            throw new RestApiException(KAKAO_ROAD_TIME_OUT);
+        } catch (Exception e) {
+            // 기타 예외 처리
+            throw new RestApiException(INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private HttpHeaders getHeader() {
+        HttpHeaders httpHeaders = new HttpHeaders();
+        String auth = "KakaoAK " + kakaoRoadApiConfig.getAdminKey();
+
+        httpHeaders.set("Authorization", auth);
+
+        return httpHeaders;
+    }
 }

--- a/hub/src/main/java/com/logistcshub/hub/hub_transfer/domain/model/HubTransfer.java
+++ b/hub/src/main/java/com/logistcshub/hub/hub_transfer/domain/model/HubTransfer.java
@@ -4,12 +4,14 @@ import com.logistcshub.hub.common.domain.model.BaseEntity;
 import com.logistcshub.hub.hub.domain.mode.Hub;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,7 +20,10 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
 
 @Entity
-@Table(name = "p_hub_transfers")
+@Table(
+        name = "p_hub_transfers",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"start_hub_id", "end_hub_id"})
+)
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
@@ -28,11 +33,11 @@ public class HubTransfer extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "start_hub_id")
     private Hub startHub;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "end_hub_id")
     private Hub endHub;
 

--- a/hub/src/main/java/com/logistcshub/hub/hub_transfer/domain/repository/HubTransferRepository.java
+++ b/hub/src/main/java/com/logistcshub/hub/hub_transfer/domain/repository/HubTransferRepository.java
@@ -1,4 +1,10 @@
 package com.logistcshub.hub.hub_transfer.domain.repository;
 
+import com.logistcshub.hub.hub.domain.mode.Hub;
+import com.logistcshub.hub.hub_transfer.domain.model.HubTransfer;
+
 public interface HubTransferRepository {
+    HubTransfer save(HubTransfer hubTransfer);
+
+    boolean existsByStartHubAndEndHubAndDeletedFalse(Hub startHub, Hub endHub);
 }

--- a/hub/src/main/java/com/logistcshub/hub/hub_transfer/infrastructure/HubTransferRepositoryImpl.java
+++ b/hub/src/main/java/com/logistcshub/hub/hub_transfer/infrastructure/HubTransferRepositoryImpl.java
@@ -1,8 +1,24 @@
 package com.logistcshub.hub.hub_transfer.infrastructure;
 
+import com.logistcshub.hub.hub.domain.mode.Hub;
+import com.logistcshub.hub.hub_transfer.domain.model.HubTransfer;
 import com.logistcshub.hub.hub_transfer.domain.repository.HubTransferRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 @Repository
+@RequiredArgsConstructor
 public class HubTransferRepositoryImpl implements HubTransferRepository {
+
+    private final JpaHubTransferRepository jpaHubTransferRepository;
+
+    @Override
+    public HubTransfer save(HubTransfer hubTransfer) {
+        return jpaHubTransferRepository.save(hubTransfer);
+    }
+
+    @Override
+    public boolean existsByStartHubAndEndHubAndDeletedFalse(Hub startHub, Hub endHub) {
+        return jpaHubTransferRepository.existsByStartHubAndEndHubAndDeletedFalse(startHub, endHub);
+    }
 }

--- a/hub/src/main/java/com/logistcshub/hub/hub_transfer/infrastructure/JpaHubTransferRepository.java
+++ b/hub/src/main/java/com/logistcshub/hub/hub_transfer/infrastructure/JpaHubTransferRepository.java
@@ -1,9 +1,11 @@
 package com.logistcshub.hub.hub_transfer.infrastructure;
 
 
+import com.logistcshub.hub.hub.domain.mode.Hub;
 import com.logistcshub.hub.hub_transfer.domain.model.HubTransfer;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JpaHubTransferRepository extends JpaRepository<HubTransfer, UUID> {
+    boolean existsByStartHubAndEndHubAndDeletedFalse(Hub startHub, Hub endHub);
 }

--- a/hub/src/main/java/com/logistcshub/hub/hub_transfer/presentation/HubTransferController.java
+++ b/hub/src/main/java/com/logistcshub/hub/hub_transfer/presentation/HubTransferController.java
@@ -1,7 +1,17 @@
 package com.logistcshub.hub.hub_transfer.presentation;
 
+import static com.logistcshub.hub.common.domain.model.type.ResponseMessage.SUCCESS_CREATE_HUB_TRANSFER;
+
+import com.logistcshub.hub.common.domain.model.dtos.SuccessResponse;
+import com.logistcshub.hub.hub_transfer.application.dtos.AddHubTransferResponseDto;
 import com.logistcshub.hub.hub_transfer.application.service.HubTransferService;
+import com.logistcshub.hub.hub_transfer.presentation.request.AddHubTransferRequestDto;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -10,4 +20,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class HubTransferController {
     private final HubTransferService hubTransferService;
+
+    @PostMapping
+    public ResponseEntity<SuccessResponse<List<AddHubTransferResponseDto>>> addHubTransfer(@RequestBody AddHubTransferRequestDto request,
+                                                                                          @RequestHeader(value = "X-USER-ID") Long userId,
+                                                                                          @RequestHeader(value = "X-USER-ROLE") String role) {
+        userId = 1L;
+        role = "MASTER";
+
+        return ResponseEntity.ok().body(
+                SuccessResponse.of(SUCCESS_CREATE_HUB_TRANSFER, hubTransferService.addHubTransfer(request, role, userId))
+        );
+    }
 }

--- a/hub/src/main/java/com/logistcshub/hub/hub_transfer/presentation/request/AddHubTransferRequestDto.java
+++ b/hub/src/main/java/com/logistcshub/hub/hub_transfer/presentation/request/AddHubTransferRequestDto.java
@@ -1,0 +1,10 @@
+package com.logistcshub.hub.hub_transfer.presentation.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.UUID;
+
+public record AddHubTransferRequestDto(
+        @JsonProperty("start-hub-id") UUID startHubId,
+        @JsonProperty("end-hub-id") UUID endHubId
+) {
+}

--- a/hub/src/main/resources/application-db.yml
+++ b/hub/src/main/resources/application-db.yml
@@ -12,9 +12,6 @@ spring:
         dialect: org.hibernate.dialect.PostgreSQLDialect
     open-in-view: false
 
-kakaomap:
-  admin-key: ${KAKAO_MAP_ADMIN_KEY}
-  map-url: ${KAKAO_MAP_URL}
 
 ---
 # Local 환경

--- a/hub/src/main/resources/application.yml
+++ b/hub/src/main/resources/application.yml
@@ -33,4 +33,12 @@ management:
       exposure:
         include: refresh
 
+kakaomap:
+  admin-key: ${KAKAO_MAP_ADMIN_KEY}
+  map-url: ${KAKAO_MAP_URL}
+
+kakaoroad:
+  admin-key: ${KAKAO_ROAD_API_ADMIN_KEY}
+  road-url: ${KAKAO_ROAD_API_URL}
+
 message: "default message"


### PR DESCRIPTION
## #️⃣연관된 이슈

> #44 

## 📝작업 내용

> 카카오 길찾기 api를 활용하여 허브 to 허브의 연결된 길을 추가하는 기능을 추가하였습니다.
- 양 허브를 지정하고 시작과 끝을 변경하여 2개의 길을 추가하는 방식으로 작성했습니다. (시간과 거리가 다르기 때문에)

![image](https://github.com/user-attachments/assets/364f4f89-561f-424e-8f6c-13dd9ae5a9a2)

![image](https://github.com/user-attachments/assets/0a64dd5a-4cb6-4b46-8022-eadefa54f310)

- 기존 isDeleted 여부와 상관 없이 작동하던 코드들을 false 일 경우만 find 하도록 변경하였습니다.


> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
