### PR TITLE
Feat: FeignClient을 통한 Company, Product 생성 기능 수정 

### DIFF
--- a/company/src/main/java/com/logistcshub/company/CompanyApplication.java
+++ b/company/src/main/java/com/logistcshub/company/CompanyApplication.java
@@ -2,8 +2,10 @@ package com.logistcshub.company;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
 public class CompanyApplication {
 
 	public static void main(String[] args) {

--- a/company/src/main/java/com/logistcshub/company/domain/service/CompanyService.java
+++ b/company/src/main/java/com/logistcshub/company/domain/service/CompanyService.java
@@ -59,4 +59,11 @@ public class CompanyService {
         return new PagedModel<>(companies.map(CompanyResponseDto::toDto));
     }
 
+    public CompanyResponseDto getCompany(UUID id) {
+        Company company = companyRepository.findById(id).orElseThrow(
+                () -> new NoSuchElementException("해당 Id값을 갖는 업체가 존재하지 않습니다."));
+
+        return CompanyResponseDto.toDto(company);
+    }
+
 }

--- a/company/src/main/java/com/logistcshub/company/presentation/controller/CompanyController.java
+++ b/company/src/main/java/com/logistcshub/company/presentation/controller/CompanyController.java
@@ -61,4 +61,11 @@ public class CompanyController {
                 .body(ApiResponse.success(MessageType.RETRIEVE, Companies));
     }
 
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<CompanyResponseDto>> getCompany(@RequestParam(value = "id", required = false) UUID id) {
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(MessageType.RETRIEVE, companyService.getCompany(id)));
+    }
+
 }

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -25,6 +25,15 @@ spring:
           uri: lb://delivery-service
           predicates:
             - Path=/api/deliveries/**, /api/delivery-routes/**
+        - id: product-service
+          uri: lb://product-service
+          predicates:
+            - Path=/api/products/**
+        - id: company-service
+          uri: lb://company-service
+          predicates:
+            - Path=/api/companies/**
+
 
       discovery:
         locator:

--- a/product/src/main/java/com/logiticshub/product/ProductApplication.java
+++ b/product/src/main/java/com/logiticshub/product/ProductApplication.java
@@ -2,8 +2,10 @@ package com.logiticshub.product;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
 public class ProductApplication {
 
 	public static void main(String[] args) {

--- a/product/src/main/java/com/logiticshub/product/application/client/CompanyClient.java
+++ b/product/src/main/java/com/logiticshub/product/application/client/CompanyClient.java
@@ -1,0 +1,20 @@
+package com.logiticshub.product.application.client;
+
+import com.logiticshub.product.application.dto.CompanyResponseDto;
+import com.logiticshub.product.presentation.response.ApiResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.data.web.PagedModel;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.UUID;
+
+@FeignClient(name = "company-service")
+public interface CompanyClient {
+
+    @GetMapping("/api/companies/{id}")
+    ResponseEntity<ApiResponse<CompanyResponseDto>> getCompany(
+            @RequestParam(value = "id", required = false) UUID companyId);
+
+}

--- a/product/src/main/java/com/logiticshub/product/application/dto/CompanyResponseDto.java
+++ b/product/src/main/java/com/logiticshub/product/application/dto/CompanyResponseDto.java
@@ -1,0 +1,18 @@
+package com.logiticshub.product.application.dto;
+
+import java.util.UUID;
+
+public record CompanyResponseDto(
+        UUID id,
+        String name,
+        String address,
+        String contact,
+        CompanyType companyType,
+        UUID hubId,
+        boolean isDelete
+
+) {
+    public enum CompanyType {
+        PRODUCTION_COMPANY, RECEIVING_COMPANY;
+    }
+}

--- a/product/src/main/java/com/logiticshub/product/domain/service/ProductService.java
+++ b/product/src/main/java/com/logiticshub/product/domain/service/ProductService.java
@@ -1,9 +1,12 @@
 package com.logiticshub.product.domain.service;
 
+import com.logiticshub.product.application.client.CompanyClient;
+import com.logiticshub.product.application.dto.CompanyResponseDto;
 import com.logiticshub.product.application.dto.ProductResponseDto;
 import com.logiticshub.product.domain.model.Product;
 import com.logiticshub.product.domain.repository.ProductRepository;
 import com.logiticshub.product.presentation.request.ProductRequestDto;
+import com.logiticshub.product.presentation.response.ApiResponse;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Predicate;
 import jakarta.ws.rs.NotFoundException;
@@ -11,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedModel;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,9 +27,13 @@ import static com.logiticshub.product.domain.model.QProduct.product;
 public class ProductService {
 
     private final ProductRepository productRepository;
+    private final CompanyClient companyClient;
 
     public ProductResponseDto createProduct(Long userId, String role, ProductRequestDto productRequestDto) {
-        Product product = productRequestDto.toEntity();
+        ResponseEntity<ApiResponse<CompanyResponseDto>> getCompanyInfo = companyClient.getCompany(productRequestDto.companyId());
+        CompanyResponseDto companyInfo= getCompanyInfo.getBody().data();
+        Product product = productRequestDto.toEntity(companyInfo.hubId());
+
         product.create(userId);
 
         productRepository.save(product);

--- a/product/src/main/java/com/logiticshub/product/presentation/request/ProductRequestDto.java
+++ b/product/src/main/java/com/logiticshub/product/presentation/request/ProductRequestDto.java
@@ -13,14 +13,14 @@ public record ProductRequestDto(
         UUID hubId
 
 ) {
-    public Product toEntity(){
+    public Product toEntity(UUID hubId){
         return Product.builder()
                 .name(this.name)
                 .description(this.description)
                 .price(this.price)
                 .stock(this.stock)
                 .companyId(this.companyId)
-                .hubId(this.hubId)
+                .hubId(hubId)
                 .build();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) 48

## 📝작업 내용

> Product 생성 시 CompanyId값만 넣어주면 해당 업체 담당 허브Id값을 호출해 Product에 저장합니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> Company Id 저장 시 주소에 따라 hubId만으로 배정이 가능한지 궁금합니다.
Product 조회 시 companyName을 호출해 반환하고 싶었지만 Get을 통한 호출은 이후 product가 증가할 경우 Url 길이 제한으로 인해 사용할 수 없을 것 같습니다. Post형식으로 id를 List로 보내는 것도 생각해봤지만 REST Api에 맞지 않는 형식인 것 같아 이 문제는 우선 개선 사항으로 남겨두었습니다. 