### PR TITLE
Feat: Hub-Transfer 수정, 삭제, 상세 조회 기능 추가

### DIFF
--- a/hub/src/main/java/com/logistcshub/hub/area/infrastructure/AreaRepositoryImpl.java
+++ b/hub/src/main/java/com/logistcshub/hub/area/infrastructure/AreaRepositoryImpl.java
@@ -27,16 +27,16 @@ public class AreaRepositoryImpl implements AreaRepository {
 
     @Override
     public Optional<Area> findById(UUID id) {
-        return jpaAreaRepository.findById(id);
+        return jpaAreaRepository.findByIdAndIsDeletedFalse(id);
     }
 
     @Override
     public Optional<Area> findByStateAndCity(State state, City city) {
-        return jpaAreaRepository.findByStateAndCity(state, city);
+        return jpaAreaRepository.findByStateAndCityAndIsDeletedFalse(state, city);
     }
 
     @Override
     public boolean existsByCity(City city) {
-        return jpaAreaRepository.existsByCity(city);
+        return jpaAreaRepository.existsByCityAndIsDeletedFalse(city);
     }
 }

--- a/hub/src/main/java/com/logistcshub/hub/area/infrastructure/JpaAreaRepository.java
+++ b/hub/src/main/java/com/logistcshub/hub/area/infrastructure/JpaAreaRepository.java
@@ -3,7 +3,7 @@ package com.logistcshub.hub.area.infrastructure;
 import com.logistcshub.hub.area.domain.model.Area;
 import com.logistcshub.hub.area.domain.model.type.City;
 import com.logistcshub.hub.area.domain.model.type.State;
-import com.logistcshub.hub.area.domain.repository.AreaRepository;
+
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,7 +11,8 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface JpaAreaRepository extends JpaRepository<Area, UUID> {
-    boolean existsByCity(City city);
+    boolean existsByCityAndIsDeletedFalse(City city);
 
-    Optional<Area> findByStateAndCity(State state, City city);
+    Optional<Area> findByStateAndCityAndIsDeletedFalse(State state, City city);
+    Optional<Area> findByIdAndIsDeletedFalse(UUID id);
 }

--- a/hub/src/main/java/com/logistcshub/hub/common/domain/model/type/ResponseMessage.java
+++ b/hub/src/main/java/com/logistcshub/hub/common/domain/model/type/ResponseMessage.java
@@ -17,9 +17,13 @@ public enum ResponseMessage {
     SUCCESS_CREATE_HUB(HttpStatus.OK, "허브 생성에 성공했습니다."),
     SUCCESS_UPDATE_HUB(HttpStatus.OK, "허브 수정에 성공했습니다."),
     SUCCESS_DELETE_HUB(HttpStatus.OK, "허브 삭제에 성공했습니다."),
+    SUCCESS_GET_HUBS(HttpStatus.OK, "허브 조회에 성공했습니다."),
     SUCCESS_GET_HUB(HttpStatus.OK, "허브 상세 조회에 성공했습니다."),
 
     SUCCESS_CREATE_HUB_TRANSFER(HttpStatus.OK, "허브 to 허브 생성에 성공했습니다."),
+    SUCCESS_UPDATE_HUB_TRANSFER(HttpStatus.OK, "허브 to 허브 수정에 성공했습니다."),
+    SUCCESS_DELETE_HUB_TRANSFER(HttpStatus.OK, "허브 to 허브 삭제에 성공했습니다."),
+    SUCCESS_GET_HUB_TRANSFER(HttpStatus.OK, "허브 to 허브 조회에 성공했습니다."),
 
     ;
     private final HttpStatus status;

--- a/hub/src/main/java/com/logistcshub/hub/common/exception/application/type/ErrorCode.java
+++ b/hub/src/main/java/com/logistcshub/hub/common/exception/application/type/ErrorCode.java
@@ -27,7 +27,9 @@ public enum ErrorCode {
 
     HUB_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 허브를 찾을 수 없습니다."),
     ALREADY_EXISTS_HUB(HttpStatus.BAD_REQUEST, "이미 존재하는 허브입니다."),
-    ALREADY_EXISTS_HUB_TRANSFER(HttpStatus.BAD_REQUEST, "이미 존재하는 경로입니다. 시간 혹은 거리를 업데이트 하시고 싶으시면 PUT 요청해주세요."),
+    ALREADY_EXISTS_HUB_TRANSFER(HttpStatus.BAD_REQUEST, "이미 존재하는 경로입니다."),
+
+    HUB_TRANSFER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 hub transfer를 찾을 수 없습니다."),
 
 
     ;

--- a/hub/src/main/java/com/logistcshub/hub/hub/infrastructure/HubRepositoryImpl.java
+++ b/hub/src/main/java/com/logistcshub/hub/hub/infrastructure/HubRepositoryImpl.java
@@ -21,16 +21,16 @@ public class HubRepositoryImpl implements HubRepository {
 
     @Override
     public Optional<Hub> findByIdAndDeletedFalse(UUID id) {
-        return jpaHubRepository.findByIdAndDeletedFalse(id);
+        return jpaHubRepository.findByIdAndIsDeletedFalse(id);
     }
 
     @Override
     public Optional<Hub> findByIdWithAreaAndDeletedFalse(UUID id) {
-        return jpaHubRepository.findByIdWithAreaAndDeletedFalse(id);
+        return jpaHubRepository.findByIdWithAreaAndIsDeletedFalse(id);
     }
 
     @Override
     public boolean existsByAreaAndAddressAndDeletedFalse(Area area, String address) {
-        return jpaHubRepository.existsByAreaAndAddressAndDeletedFalse(area, address);
+        return jpaHubRepository.existsByAreaAndAddressAndIsDeletedFalse(area, address);
     }
 }

--- a/hub/src/main/java/com/logistcshub/hub/hub/infrastructure/JpaHubRepository.java
+++ b/hub/src/main/java/com/logistcshub/hub/hub/infrastructure/JpaHubRepository.java
@@ -11,9 +11,9 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface JpaHubRepository extends JpaRepository<Hub, UUID> {
     @Query("select h from Hub h join fetch h.area where h.id = :id and h.isDeleted is false")
-    Optional<Hub> findByIdWithAreaAndDeletedFalse(UUID id);
+    Optional<Hub> findByIdWithAreaAndIsDeletedFalse(UUID id);
 
-    boolean existsByAreaAndAddressAndDeletedFalse(Area area, String address);
+    boolean existsByAreaAndAddressAndIsDeletedFalse(Area area, String address);
 
-    Optional<Hub> findByIdAndDeletedFalse(UUID id);
+    Optional<Hub> findByIdAndIsDeletedFalse(UUID id);
 }

--- a/hub/src/main/java/com/logistcshub/hub/hub/presentation/HubController.java
+++ b/hub/src/main/java/com/logistcshub/hub/hub/presentation/HubController.java
@@ -1,10 +1,5 @@
 package com.logistcshub.hub.hub.presentation;
 
-import static com.logistcshub.hub.common.domain.model.type.ResponseMessage.SUCCESS_CREATE_HUB;
-import static com.logistcshub.hub.common.domain.model.type.ResponseMessage.SUCCESS_DELETE_HUB;
-import static com.logistcshub.hub.common.domain.model.type.ResponseMessage.SUCCESS_GET_HUB;
-import static com.logistcshub.hub.common.domain.model.type.ResponseMessage.SUCCESS_UPDATE_HUB;
-
 import com.logistcshub.hub.common.domain.model.dtos.SuccessResponse;
 import com.logistcshub.hub.hub.application.dtos.AddHubResponseDto;
 import com.logistcshub.hub.hub.application.dtos.DeleteHubResponseDto;
@@ -31,6 +26,8 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import static com.logistcshub.hub.common.domain.model.type.ResponseMessage.*;
 
 @RestController
 @RequestMapping("/api/hubs")
@@ -102,7 +99,7 @@ public class HubController {
         role = "MASTER";
 
         return ResponseEntity.ok().body(
-                SuccessResponse.of(SUCCESS_GET_HUB, hubService.searchHubs(userId, role, keyword, type, pageable, sortBy, isAsc))
+                SuccessResponse.of(SUCCESS_GET_HUBS, hubService.searchHubs(userId, role, keyword, type, pageable, sortBy, isAsc))
         );
     }
 

--- a/hub/src/main/java/com/logistcshub/hub/hub_transfer/application/dtos/DeleteHubTransferResponseDto.java
+++ b/hub/src/main/java/com/logistcshub/hub/hub_transfer/application/dtos/DeleteHubTransferResponseDto.java
@@ -1,0 +1,6 @@
+package com.logistcshub.hub.hub_transfer.application.dtos;
+
+public record DeleteHubTransferResponseDto(
+        String message
+) {
+}

--- a/hub/src/main/java/com/logistcshub/hub/hub_transfer/application/dtos/HubTransferResponseDto.java
+++ b/hub/src/main/java/com/logistcshub/hub/hub_transfer/application/dtos/HubTransferResponseDto.java
@@ -1,0 +1,26 @@
+package com.logistcshub.hub.hub_transfer.application.dtos;
+
+import com.logistcshub.hub.hub_transfer.domain.model.HubTransfer;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public record HubTransferResponseDto(
+        UUID startHubId,
+        String startHubName,
+        UUID endHubId,
+        String endHubName,
+        Integer time_taken,
+        Integer distance
+) {
+    public static HubTransferResponseDto of(HubTransfer hubTransfer) {
+        return new HubTransferResponseDto(
+                hubTransfer.getStartHub().getId(),
+                hubTransfer.getStartHub().getName(),
+                hubTransfer.getEndHub().getId(),
+                hubTransfer.getEndHub().getName(),
+                hubTransfer.getTimeTaken(),
+                hubTransfer.getDistance()
+        );
+    }
+}

--- a/hub/src/main/java/com/logistcshub/hub/hub_transfer/application/dtos/UpdateHubTransferResponseDto.java
+++ b/hub/src/main/java/com/logistcshub/hub/hub_transfer/application/dtos/UpdateHubTransferResponseDto.java
@@ -1,0 +1,29 @@
+package com.logistcshub.hub.hub_transfer.application.dtos;
+
+import com.logistcshub.hub.hub.domain.mode.Hub;
+import com.logistcshub.hub.hub_transfer.domain.model.HubTransfer;
+
+import java.util.UUID;
+
+
+public record UpdateHubTransferResponseDto (
+        UUID id,
+        UUID startHubId,
+        String startHubName,
+        UUID endHubId,
+        String endHubName,
+        Integer time_taken,
+        Integer distance
+) {
+    public static UpdateHubTransferResponseDto of(HubTransfer transfer, Hub startHub, Hub endHub){
+        return new UpdateHubTransferResponseDto(
+                transfer.getId(),
+                startHub.getId(),
+                startHub.getName(),
+                endHub.getId(),
+                endHub.getName(),
+                transfer.getTimeTaken(),
+                transfer.getDistance()
+        );
+    }
+}

--- a/hub/src/main/java/com/logistcshub/hub/hub_transfer/application/service/HubTransferService.java
+++ b/hub/src/main/java/com/logistcshub/hub/hub_transfer/application/service/HubTransferService.java
@@ -1,12 +1,5 @@
 package com.logistcshub.hub.hub_transfer.application.service;
 
-import static com.logistcshub.hub.common.exception.application.type.ErrorCode.ALREADY_EXISTS_HUB_TRANSFER;
-import static com.logistcshub.hub.common.exception.application.type.ErrorCode.HUB_NOT_FOUND;
-import static com.logistcshub.hub.common.exception.application.type.ErrorCode.INTERNAL_SERVER_ERROR;
-import static com.logistcshub.hub.common.exception.application.type.ErrorCode.KAKAO_ROAD_CLIENT_ERROR;
-import static com.logistcshub.hub.common.exception.application.type.ErrorCode.KAKAO_ROAD_SERVER_ERROR;
-import static com.logistcshub.hub.common.exception.application.type.ErrorCode.KAKAO_ROAD_TIME_OUT;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.logistcshub.hub.common.config.KakaoRoadApiConfig;
 import com.logistcshub.hub.common.domain.model.dtos.KakaoResponse;
@@ -16,6 +9,9 @@ import com.logistcshub.hub.common.exception.RestApiException;
 import com.logistcshub.hub.hub.domain.mode.Hub;
 import com.logistcshub.hub.hub.domain.repository.HubRepository;
 import com.logistcshub.hub.hub_transfer.application.dtos.AddHubTransferResponseDto;
+import com.logistcshub.hub.hub_transfer.application.dtos.DeleteHubTransferResponseDto;
+import com.logistcshub.hub.hub_transfer.application.dtos.HubTransferResponseDto;
+import com.logistcshub.hub.hub_transfer.application.dtos.UpdateHubTransferResponseDto;
 import com.logistcshub.hub.hub_transfer.domain.model.HubTransfer;
 import com.logistcshub.hub.hub_transfer.domain.repository.HubTransferRepository;
 import com.logistcshub.hub.hub_transfer.presentation.request.AddHubTransferRequestDto;
@@ -24,6 +20,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+
+import com.logistcshub.hub.hub_transfer.presentation.request.UpdateTransferRequestDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpEntity;
@@ -39,6 +38,8 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import static com.logistcshub.hub.common.exception.application.type.ErrorCode.*;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -51,31 +52,73 @@ public class HubTransferService {
     @Transactional
     public List<AddHubTransferResponseDto> addHubTransfer(AddHubTransferRequestDto request, String role, Long userId) {
 
-        Hub startHub = hubRepository.findByIdAndDeletedFalse(request.startHubId()).orElseThrow(() ->
-                new RestApiException(HUB_NOT_FOUND));
+        Hub startHub = getHubById(request.startHubId());
 
-        Hub endHub = hubRepository.findByIdAndDeletedFalse(request.endHubId()).orElseThrow(() ->
-                new RestApiException(HUB_NOT_FOUND));
+        Hub endHub = getHubById(request.endHubId());
 
-        if(hubTransferRepository.existsByStartHubAndEndHubAndDeletedFalse(startHub, endHub)) {
+        if(hubTransferRepository.existsByStartHubAndEndHubAndIsDeletedFalse(startHub, endHub)) {
             throw new RestApiException(ALREADY_EXISTS_HUB_TRANSFER);
         }
 
         HubTransfer startToEnd = extracted(startHub, endHub);
-        HubTransfer endToStart = extracted(endHub, startHub);
+        startToEnd.create(userId);
 
         startToEnd = hubTransferRepository.save(startToEnd);
-        endToStart = hubTransferRepository.save(endToStart);
 
         AddHubTransferResponseDto startToEndDto = AddHubTransferResponseDto.of(startToEnd, startHub, endHub);
-        AddHubTransferResponseDto endToStartDto = AddHubTransferResponseDto.of(endToStart, endHub, startHub);
 
         List<AddHubTransferResponseDto> responseDtos = new ArrayList<>();
         responseDtos.add(startToEndDto);
-        responseDtos.add(endToStartDto);
+
+        if(!hubTransferRepository.existsByStartHubAndEndHubAndIsDeletedFalse(endHub, startHub)) {
+            HubTransfer endToStart = extracted(endHub, startHub);
+
+            endToStart.create(userId);
+
+            endToStart = hubTransferRepository.save(endToStart);
+
+            AddHubTransferResponseDto endToStartDto = AddHubTransferResponseDto.of(endToStart, endHub, startHub);
+
+            responseDtos.add(endToStartDto);
+        }
 
         return responseDtos;
     }
+
+    @Transactional
+    public UpdateHubTransferResponseDto updateTransfer(UUID id, UpdateTransferRequestDto request, String role, Long userId) {
+        HubTransfer hubTransfer = getHubTransferById(id);
+
+        Hub startHub = getHubById(request.startHubId());
+
+        Hub endHub = getHubById(request.endHubId());
+
+        if(hubTransferRepository.existsByStartHubAndEndHubAndIsDeletedFalse(startHub, endHub)) {
+            throw new RestApiException(ALREADY_EXISTS_HUB_TRANSFER);
+        }
+
+        HubTransfer updatedHubTransfer = extracted(startHub, endHub);
+        hubTransfer.updateHubTransfer(startHub, endHub, updatedHubTransfer.getTimeTaken(), updatedHubTransfer.getDistance(), userId);
+
+        return UpdateHubTransferResponseDto.of(hubTransferRepository.save(hubTransfer), startHub, endHub);
+
+    }
+
+    @Transactional
+    public DeleteHubTransferResponseDto deleteHubTransfer(UUID id, String role, Long userId) {
+        HubTransfer hubTransfer = getHubTransferById(id);
+
+        hubTransferRepository.delete(hubTransfer);
+
+        return new DeleteHubTransferResponseDto(hubTransfer.getStartHub().getName() + "에서 " + hubTransfer.getEndHub().getName() + "로 연결된 노선은 삭제되었습니다.");
+
+    }
+
+    @Transactional(readOnly = true)
+    public HubTransferResponseDto getHubTransfer(UUID id, String role, Long userId) {
+        return HubTransferResponseDto.of(getHubTransferById(id));
+    }
+
 
     private HubTransfer extracted(Hub startHub, Hub endHub) {
         try {
@@ -129,4 +172,17 @@ public class HubTransferService {
 
         return httpHeaders;
     }
+
+
+    private Hub getHubById(UUID hubId) {
+        return hubRepository.findByIdAndDeletedFalse(hubId).orElseThrow(() ->
+                new RestApiException(HUB_NOT_FOUND));
+    }
+
+    private HubTransfer getHubTransferById(UUID id) {
+        return hubTransferRepository.findByIdAndIsDeletedFalse(id).orElseThrow(() ->
+                new RestApiException(HUB_TRANSFER_NOT_FOUND));
+    }
+
+
 }

--- a/hub/src/main/java/com/logistcshub/hub/hub_transfer/domain/model/HubTransfer.java
+++ b/hub/src/main/java/com/logistcshub/hub/hub_transfer/domain/model/HubTransfer.java
@@ -20,10 +20,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
 
 @Entity
-@Table(
-        name = "p_hub_transfers",
-        uniqueConstraints = @UniqueConstraint(columnNames = {"start_hub_id", "end_hub_id"})
-)
+@Table(name = "p_hub_transfers")
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
@@ -49,5 +46,12 @@ public class HubTransfer extends BaseEntity {
     @Column(name = "distance")
     private Integer distance;
 
+    public void updateHubTransfer(Hub startHub, Hub endHub, Integer timeTaken, Integer distance, Long userId) {
+        this.startHub = startHub;
+        this.endHub = endHub;
+        this.timeTaken = timeTaken;
+        this.distance = distance;
+        update(userId);
+    }
 
 }

--- a/hub/src/main/java/com/logistcshub/hub/hub_transfer/domain/repository/HubTransferRepository.java
+++ b/hub/src/main/java/com/logistcshub/hub/hub_transfer/domain/repository/HubTransferRepository.java
@@ -3,8 +3,15 @@ package com.logistcshub.hub.hub_transfer.domain.repository;
 import com.logistcshub.hub.hub.domain.mode.Hub;
 import com.logistcshub.hub.hub_transfer.domain.model.HubTransfer;
 
+import java.util.Optional;
+import java.util.UUID;
+
 public interface HubTransferRepository {
     HubTransfer save(HubTransfer hubTransfer);
 
-    boolean existsByStartHubAndEndHubAndDeletedFalse(Hub startHub, Hub endHub);
+    boolean existsByStartHubAndEndHubAndIsDeletedFalse(Hub startHub, Hub endHub);
+
+    Optional<HubTransfer> findByIdAndIsDeletedFalse(UUID id);
+
+    void delete(HubTransfer hubTransfer);
 }

--- a/hub/src/main/java/com/logistcshub/hub/hub_transfer/infrastructure/HubTransferRepositoryImpl.java
+++ b/hub/src/main/java/com/logistcshub/hub/hub_transfer/infrastructure/HubTransferRepositoryImpl.java
@@ -6,6 +6,9 @@ import com.logistcshub.hub.hub_transfer.domain.repository.HubTransferRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+import java.util.UUID;
+
 @Repository
 @RequiredArgsConstructor
 public class HubTransferRepositoryImpl implements HubTransferRepository {
@@ -18,7 +21,17 @@ public class HubTransferRepositoryImpl implements HubTransferRepository {
     }
 
     @Override
-    public boolean existsByStartHubAndEndHubAndDeletedFalse(Hub startHub, Hub endHub) {
-        return jpaHubTransferRepository.existsByStartHubAndEndHubAndDeletedFalse(startHub, endHub);
+    public boolean existsByStartHubAndEndHubAndIsDeletedFalse(Hub startHub, Hub endHub) {
+        return jpaHubTransferRepository.existsByStartHubAndEndHubAndIsDeletedFalse(startHub, endHub);
+    }
+
+    @Override
+    public Optional<HubTransfer> findByIdAndIsDeletedFalse(UUID id) {
+        return jpaHubTransferRepository.findByIdAndIsDeletedFalse(id);
+    }
+
+    @Override
+    public void delete(HubTransfer hubTransfer) {
+        jpaHubTransferRepository.delete(hubTransfer);
     }
 }

--- a/hub/src/main/java/com/logistcshub/hub/hub_transfer/infrastructure/JpaHubTransferRepository.java
+++ b/hub/src/main/java/com/logistcshub/hub/hub_transfer/infrastructure/JpaHubTransferRepository.java
@@ -3,9 +3,15 @@ package com.logistcshub.hub.hub_transfer.infrastructure;
 
 import com.logistcshub.hub.hub.domain.mode.Hub;
 import com.logistcshub.hub.hub_transfer.domain.model.HubTransfer;
+
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface JpaHubTransferRepository extends JpaRepository<HubTransfer, UUID> {
-    boolean existsByStartHubAndEndHubAndDeletedFalse(Hub startHub, Hub endHub);
+    boolean existsByStartHubAndEndHubAndIsDeletedFalse(Hub startHub, Hub endHub);
+
+    @Query("select ht from HubTransfer ht join fetch ht.startHub join fetch ht.endHub where ht.id = :id and ht.isDeleted is false ")
+    Optional<HubTransfer> findByIdAndIsDeletedFalse(UUID id);
 }

--- a/hub/src/main/java/com/logistcshub/hub/hub_transfer/presentation/HubTransferController.java
+++ b/hub/src/main/java/com/logistcshub/hub/hub_transfer/presentation/HubTransferController.java
@@ -1,19 +1,21 @@
 package com.logistcshub.hub.hub_transfer.presentation;
 
-import static com.logistcshub.hub.common.domain.model.type.ResponseMessage.SUCCESS_CREATE_HUB_TRANSFER;
-
 import com.logistcshub.hub.common.domain.model.dtos.SuccessResponse;
 import com.logistcshub.hub.hub_transfer.application.dtos.AddHubTransferResponseDto;
+import com.logistcshub.hub.hub_transfer.application.dtos.DeleteHubTransferResponseDto;
+import com.logistcshub.hub.hub_transfer.application.dtos.HubTransferResponseDto;
+import com.logistcshub.hub.hub_transfer.application.dtos.UpdateHubTransferResponseDto;
 import com.logistcshub.hub.hub_transfer.application.service.HubTransferService;
 import com.logistcshub.hub.hub_transfer.presentation.request.AddHubTransferRequestDto;
 import java.util.List;
+import java.util.UUID;
+
+import com.logistcshub.hub.hub_transfer.presentation.request.UpdateTransferRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import static com.logistcshub.hub.common.domain.model.type.ResponseMessage.*;
 
 @RequestMapping("/api/hub-transfers")
 @RestController
@@ -30,6 +32,43 @@ public class HubTransferController {
 
         return ResponseEntity.ok().body(
                 SuccessResponse.of(SUCCESS_CREATE_HUB_TRANSFER, hubTransferService.addHubTransfer(request, role, userId))
+        );
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<SuccessResponse<UpdateHubTransferResponseDto>> updateHubTransfer(@PathVariable UUID id,
+                                                                                            @RequestBody UpdateTransferRequestDto request,
+                                                                                            @RequestHeader(value = "X-USER-ID") Long userId,
+                                                                                            @RequestHeader(value = "X-USER-ROLE") String role) {
+        userId = 1L;
+        role = "MASTER";
+
+        return ResponseEntity.ok().body(
+                SuccessResponse.of(SUCCESS_UPDATE_HUB_TRANSFER, hubTransferService.updateTransfer(id, request, role, userId))
+        );
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<SuccessResponse<DeleteHubTransferResponseDto>> deleteHubTransfer(@PathVariable UUID id,
+                                                                                           @RequestHeader(value = "X-USER-ID") Long userId,
+                                                                                           @RequestHeader(value = "X-USER-ROLE") String role) {
+        userId = 1L;
+        role = "MASTER";
+
+        return ResponseEntity.ok().body(
+                SuccessResponse.of(SUCCESS_DELETE_HUB_TRANSFER, hubTransferService.deleteHubTransfer(id, role, userId))
+        );
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<SuccessResponse<HubTransferResponseDto>> getHubTransfer(@PathVariable UUID id,
+                                                                                  @RequestHeader(value = "X-USER-ID") Long userId,
+                                                                                  @RequestHeader(value = "X-USER-ROLE") String role) {
+        userId = 1L;
+        role = "MASTER";
+
+        return ResponseEntity.ok().body(
+                SuccessResponse.of(SUCCESS_GET_HUB_TRANSFER, hubTransferService.getHubTransfer(id, role, userId))
         );
     }
 }

--- a/hub/src/main/java/com/logistcshub/hub/hub_transfer/presentation/request/UpdateTransferRequestDto.java
+++ b/hub/src/main/java/com/logistcshub/hub/hub_transfer/presentation/request/UpdateTransferRequestDto.java
@@ -1,0 +1,11 @@
+package com.logistcshub.hub.hub_transfer.presentation.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.UUID;
+
+public record UpdateTransferRequestDto (
+        @JsonProperty("start-hub-id") UUID startHubId,
+        @JsonProperty("end-hub-id") UUID endHubId
+) {
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #53 

## 📝작업 내용

> Hub-transfer 수정, 삭제, 상세 조회 기능 추가하였습니다.
- 수정
  - 성공
    ![image](https://github.com/user-attachments/assets/f587d9e6-9aad-499b-b2cc-d1c9dec9b7d0)

  - 실패 ( 같은 경로가 있는 경우)
    ![image](https://github.com/user-attachments/assets/df61b926-3020-4527-bfbd-f4cd61258bae)

- 삭제
  ![image](https://github.com/user-attachments/assets/53b93ca3-0f6c-4eb3-b08c-73c176352fa3)

- 상세 조회
![image](https://github.com/user-attachments/assets/d32c4f51-8a60-4f2a-9d46-db9efcdb74a4)

> DeletedFalse 에서 IsDeletedFalse 로 바꾸었습니다. 제대로 확인 안하고 저번 pr 올려서 죄송합니다...!

> 기존 Hub-transfer 에 startHub와 endHub의 아이디를 합쳐서 유니크 조건을 걸었었습니다. 하지만 소프트 삭제를 하기 때문에 삭제 후 같은 경로가 추가되어야 할 때 추가가 되지 않아 해당 조건을 삭제하였습니다.


## 💬리뷰 요구사항(선택)

