### PR TITLE
Feat: Hub-Transfer 검색 기능 추가 및 서버 실행 시 초기 연결 되어 있는 허브 inserter 추가

### DIFF
--- a/hub/build.gradle
+++ b/hub/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    implementation 'org.jetbrains:annotations:24.1.0'
 
     // https://mvnrepository.com/artifact/com.google.code.gson/gson
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.11.0'

--- a/hub/src/main/java/com/logistcshub/hub/common/domain/model/type/ResponseMessage.java
+++ b/hub/src/main/java/com/logistcshub/hub/common/domain/model/type/ResponseMessage.java
@@ -21,6 +21,10 @@ public enum ResponseMessage {
 
     SUCCESS_CREATE_HUB_TRANSFER(HttpStatus.OK, "허브 to 허브 생성에 성공했습니다."),
 
+
+
+    SUCCESS_SEARCH_HUB_TRANSFERS(HttpStatus.OK, "Hub-Transfer 검색에 성공했습니다.")
+
     ;
     private final HttpStatus status;
     private final String message;

--- a/hub/src/main/java/com/logistcshub/hub/hub/infrastructure/HubRepositoryImpl.java
+++ b/hub/src/main/java/com/logistcshub/hub/hub/infrastructure/HubRepositoryImpl.java
@@ -3,6 +3,8 @@ package com.logistcshub.hub.hub.infrastructure;
 import com.logistcshub.hub.area.domain.model.Area;
 import com.logistcshub.hub.hub.domain.mode.Hub;
 import com.logistcshub.hub.hub.domain.repository.HubRepository;
+
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +23,7 @@ public class HubRepositoryImpl implements HubRepository {
 
     @Override
     public Optional<Hub> findByIdAndDeletedFalse(UUID id) {
-        return jpaHubRepository.findByIdAndDeletedFalse(id);
+        return jpaHubRepository.findByIdAndIsDeletedFalse(id);
     }
 
     @Override
@@ -31,6 +33,11 @@ public class HubRepositoryImpl implements HubRepository {
 
     @Override
     public boolean existsByAreaAndAddressAndDeletedFalse(Area area, String address) {
-        return jpaHubRepository.existsByAreaAndAddressAndDeletedFalse(area, address);
+        return jpaHubRepository.existsByAreaAndAddressAndIsDeletedFalse(area, address);
+    }
+
+    @Override
+    public List<Hub> findAll() {
+        return jpaHubRepository.findByIsDeletedFalse();
     }
 }

--- a/hub/src/main/java/com/logistcshub/hub/hub/infrastructure/JpaHubRepository.java
+++ b/hub/src/main/java/com/logistcshub/hub/hub/infrastructure/JpaHubRepository.java
@@ -2,6 +2,8 @@ package com.logistcshub.hub.hub.infrastructure;
 
 import com.logistcshub.hub.area.domain.model.Area;
 import com.logistcshub.hub.hub.domain.mode.Hub;
+
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,7 +15,9 @@ public interface JpaHubRepository extends JpaRepository<Hub, UUID> {
     @Query("select h from Hub h join fetch h.area where h.id = :id and h.isDeleted is false")
     Optional<Hub> findByIdWithAreaAndDeletedFalse(UUID id);
 
-    boolean existsByAreaAndAddressAndDeletedFalse(Area area, String address);
+    boolean existsByAreaAndAddressAndIsDeletedFalse(Area area, String address);
 
-    Optional<Hub> findByIdAndDeletedFalse(UUID id);
+    Optional<Hub> findByIdAndIsDeletedFalse(UUID id);
+
+    List<Hub> findByIsDeletedFalse();
 }

--- a/hub/src/main/java/com/logistcshub/hub/hub_transfer/application/config/AddHubTransferInserter.java
+++ b/hub/src/main/java/com/logistcshub/hub/hub_transfer/application/config/AddHubTransferInserter.java
@@ -1,0 +1,92 @@
+package com.logistcshub.hub.hub_transfer.application.config;
+
+import com.logistcshub.hub.hub.application.service.HubService;
+import com.logistcshub.hub.hub.domain.mode.Hub;
+import com.logistcshub.hub.hub.domain.repository.HubRepository;
+import com.logistcshub.hub.hub_transfer.application.service.HubTransferService;
+import com.logistcshub.hub.hub_transfer.domain.model.HubTransfer;
+import com.logistcshub.hub.hub_transfer.domain.repository.HubTransferRepository;
+import com.logistcshub.hub.hub_transfer.presentation.request.AddHubTransferRequestDto;
+import jakarta.annotation.PostConstruct;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@AllArgsConstructor
+public class AddHubTransferInserter {
+
+    private final HubRepository hubRepository;
+    private final HubTransferRepository hubTransferRepository;
+    private final HubTransferService hubTransferService;
+
+    private static String[][] hubToHub = new String[][] {
+            // 경기 남부 센터
+            {"경기 남부 센터", "경기 북부 센터"},
+            {"경기 남부 센터", "서울특별시 센터"},
+            {"경기 남부 센터", "인천광역시 센터"},
+            {"경기 남부 센터", "강원특별자치도 센터"},
+            {"경기 남부 센터", "경상북도 센터"},
+            {"경기 남부 센터", "대전광역시 센터"},
+            {"경기 남부 센터", "대구광역시 센터"},
+
+            // 대전 광역시 센터
+            {"대전광역시 센터", "충청남도 센터"},
+            {"대전광역시 센터", "충청북도 센터"},
+            {"대전광역시 센터", "세종특별자치시 센터"},
+            {"대전광역시 센터", "전북특별자치도 센터"},
+            {"대전광역시 센터", "광주광역시 센터"},
+            {"대전광역시 센터", "전라남도 센터"},
+            {"대전광역시 센터", "대구광역시 센터"},
+
+            // 대구 광역시 센터
+            {"대구광역시 센터", "경상북도 센터"},
+            {"대구광역시 센터", "경상남도 센터"},
+            {"대구광역시 센터", "부산광역시 센터"},
+            {"대구광역시 센터", "울산광역시 센터"},
+    };
+
+    @PostConstruct
+    public void init() {
+
+        Long userid = 1L;
+        String role = "MASTER";
+        List<HubTransfer> saveList = new ArrayList<>();
+
+        Map<String, Hub> hubMap = new HashMap<>();
+
+        hubRepository.findAll().forEach(hub ->  hubMap.put(hub.getName(), hub));
+
+        for(String[] hubs : hubToHub) {
+            Hub hub1 = hubMap.get(hubs[0]);
+            Hub hub2 = hubMap.get(hubs[1]);
+
+            if(!hubTransferRepository.existsByStartHubAndEndHubAndDeletedFalse(hub1, hub2)) {
+                HubTransfer hubTransfer = hubTransferService.extracted(hub1, hub2);
+                hubTransfer.create(userid);
+                saveList.add(hubTransfer);
+            }
+
+            if(!hubTransferRepository.existsByStartHubAndEndHubAndDeletedFalse(hub2, hub1)) {
+                HubTransfer hubTransfer = hubTransferService.extracted(hub2, hub1);
+                hubTransfer.create(userid);
+                saveList.add(hubTransfer);
+            }
+
+            try {
+                Thread.sleep(500); // 500 milliseconds
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt(); // 인터럽트 상태 복구
+                System.err.println("Thread was interrupted during sleep.");
+            }
+        }
+
+        hubTransferRepository.saveAll(saveList);
+
+
+    }
+}

--- a/hub/src/main/java/com/logistcshub/hub/hub_transfer/application/dtos/HubTransferPageDto.java
+++ b/hub/src/main/java/com/logistcshub/hub/hub_transfer/application/dtos/HubTransferPageDto.java
@@ -1,0 +1,77 @@
+package com.logistcshub.hub.hub_transfer.application.dtos;
+
+import com.logistcshub.hub.hub_transfer.domain.model.HubTransfer;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.web.PagedModel;
+
+import java.util.List;
+import java.util.UUID;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class HubTransferPageDto  {
+
+    private HubTransferPage hubTransferPage;
+
+    public static HubTransferPageDto of(Page<HubTransferPage.HubTransfer> hubTransferPage) {
+        return HubTransferPageDto.builder()
+                .hubTransferPage(new HubTransferPage(hubTransferPage))
+                .build();
+    }
+
+    @Getter
+    @ToString
+    public static class HubTransferPage extends PagedModel<HubTransferPage.HubTransfer> {
+        public HubTransferPage(Page<HubTransfer> page) {
+            super(new PageImpl<>(
+                    page.getContent(),
+                    page.getPageable(),
+                    page.getTotalElements()
+            ));
+        }
+
+        @Getter
+        @Builder
+        public static class HubTransfer {
+            private UUID id;
+            private String startHub;
+            private String endHub;
+            private Integer timeTaken;
+            private Integer distance;
+
+            @QueryProjection
+            public HubTransfer(UUID id, String startHub, String endHub, Integer timeTaken, Integer distance) {
+                this.id = id;
+                this.startHub = startHub;
+                this.endHub = endHub;
+                this.timeTaken = timeTaken;
+                this.distance = distance;
+            }
+
+            public static List<HubTransfer> from(List<com.logistcshub.hub.hub_transfer.domain.model.HubTransfer> hubTransferList) {
+                return hubTransferList.stream()
+                        .map(HubTransfer::from)
+                        .toList();
+            }
+
+            public static HubTransfer from(com.logistcshub.hub.hub_transfer.domain.model.HubTransfer hubTransfer) {
+                return HubTransfer.builder()
+                        .id(hubTransfer.getId())
+                        .startHub(hubTransfer.getStartHub().getName())
+                        .endHub(hubTransfer.getEndHub().getName())
+                        .timeTaken(hubTransfer.getTimeTaken())
+                        .distance(hubTransfer.getDistance())
+                        .build();
+            }
+    }
+
+
+    }
+}

--- a/hub/src/main/java/com/logistcshub/hub/hub_transfer/domain/model/HubTransfer.java
+++ b/hub/src/main/java/com/logistcshub/hub/hub_transfer/domain/model/HubTransfer.java
@@ -12,6 +12,8 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+
+import java.util.List;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -21,8 +23,7 @@ import org.hibernate.annotations.Comment;
 
 @Entity
 @Table(
-        name = "p_hub_transfers",
-        uniqueConstraints = @UniqueConstraint(columnNames = {"start_hub_id", "end_hub_id"})
+        name = "p_hub_transfers"
 )
 @AllArgsConstructor
 @NoArgsConstructor

--- a/hub/src/main/java/com/logistcshub/hub/hub_transfer/domain/repository/HubTransferRepository.java
+++ b/hub/src/main/java/com/logistcshub/hub/hub_transfer/domain/repository/HubTransferRepository.java
@@ -1,10 +1,20 @@
 package com.logistcshub.hub.hub_transfer.domain.repository;
 
 import com.logistcshub.hub.hub.domain.mode.Hub;
+import com.logistcshub.hub.hub_transfer.application.dtos.HubTransferPageDto;
 import com.logistcshub.hub.hub_transfer.domain.model.HubTransfer;
+import com.querydsl.core.types.Predicate;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.UUID;
 
 public interface HubTransferRepository {
     HubTransfer save(HubTransfer hubTransfer);
 
     boolean existsByStartHubAndEndHubAndDeletedFalse(Hub startHub, Hub endHub);
+
+    HubTransferPageDto findAll(List<UUID> idList, Predicate predicate, Pageable pageable);
+
+    List<HubTransfer> saveAll(List<HubTransfer> saveList);
 }

--- a/hub/src/main/java/com/logistcshub/hub/hub_transfer/infrastructure/HubTransferRepositoryImpl.java
+++ b/hub/src/main/java/com/logistcshub/hub/hub_transfer/infrastructure/HubTransferRepositoryImpl.java
@@ -1,16 +1,40 @@
 package com.logistcshub.hub.hub_transfer.infrastructure;
 
 import com.logistcshub.hub.hub.domain.mode.Hub;
+import com.logistcshub.hub.hub_transfer.application.dtos.HubTransferPageDto;
+import com.logistcshub.hub.hub_transfer.application.dtos.QHubTransferPageDto_HubTransferPage_HubTransfer;
 import com.logistcshub.hub.hub_transfer.domain.model.HubTransfer;
 import com.logistcshub.hub.hub_transfer.domain.repository.HubTransferRepository;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.core.types.dsl.StringPath;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static com.logistcshub.hub.hub.domain.mode.QHub.hub;
+import static com.logistcshub.hub.hub_transfer.domain.model.QHubTransfer.hubTransfer;
+
 
 @Repository
 @RequiredArgsConstructor
 public class HubTransferRepositoryImpl implements HubTransferRepository {
 
     private final JpaHubTransferRepository jpaHubTransferRepository;
+    private final JPAQueryFactory queryFactory;
 
     @Override
     public HubTransfer save(HubTransfer hubTransfer) {
@@ -19,6 +43,86 @@ public class HubTransferRepositoryImpl implements HubTransferRepository {
 
     @Override
     public boolean existsByStartHubAndEndHubAndDeletedFalse(Hub startHub, Hub endHub) {
-        return jpaHubTransferRepository.existsByStartHubAndEndHubAndDeletedFalse(startHub, endHub);
+        return jpaHubTransferRepository.existsByStartHubAndEndHubAndIsDeletedFalse(startHub, endHub);
     }
+
+    @Override
+    public HubTransferPageDto findAll(List<UUID> idList, Predicate predicate, Pageable pageable) {
+        BooleanBuilder builder = new BooleanBuilder(predicate);
+
+        if(idList != null && !idList.isEmpty()) {
+            builder.and(hubTransfer.id.in(idList));
+        }
+
+        builder.and(hubTransfer.isDeleted.eq(false));
+
+        JPAQuery<HubTransferPageDto.HubTransferPage.HubTransfer> query = queryFactory
+                .select(new QHubTransferPageDto_HubTransferPage_HubTransfer(
+                        hubTransfer.id,
+                        hubTransfer.startHub.name,
+                        hubTransfer.endHub.name,
+                        hubTransfer.timeTaken,
+                        hubTransfer.distance
+                ))
+                .from(hubTransfer)
+                .join(hubTransfer.startHub)
+                .join(hubTransfer.endHub)
+                .where(builder)
+                .orderBy(buildOrderBy(pageable.getSort()))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize());
+
+        List<HubTransferPageDto.HubTransferPage.HubTransfer> content = query.fetch();
+
+        // 전체 카운트
+        Long total = queryFactory
+                .select(hubTransfer.count())
+                .from(hubTransfer)
+                .where(builder)
+                .fetchOne();
+
+        // Page 객체 생성
+        Page<HubTransferPageDto.HubTransferPage.HubTransfer> page = new PageImpl<>(content, pageable, total != null ? total : 0);
+
+        // HubTransferPageDto 생성 및 반환
+        return HubTransferPageDto.builder()
+                .hubTransferPage(new HubTransferPageDto.HubTransferPage(page)).build();
+    }
+
+    @Override
+    public List<HubTransfer> saveAll(List<HubTransfer> saveList) {
+        return jpaHubTransferRepository.saveAll(saveList);
+    }
+
+    private OrderSpecifier<?>[] buildOrderBy(Sort sort) {
+        if (sort.isEmpty()) {
+            // 기본 정렬 기준 추가 (예: id 기준 오름차순)
+            return new OrderSpecifier<?>[] { hubTransfer.id.desc() }; // 기본적으로 ID로 오름차순 정렬
+        }
+
+        List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
+
+        for (Sort.Order order : sort) {
+            // 필드 타입에 따라 PathBuilder를 다르게 사용
+            if (order.getProperty().equals("startHub")) {
+                OrderSpecifier<?> orderSpecifier = order.isAscending() ? hubTransfer.startHub.name.asc() : hubTransfer.startHub.name.desc();
+                orderSpecifiers.add(orderSpecifier);
+            } else if (order.getProperty().equals("timeTaken")) {
+                OrderSpecifier<?> orderSpecifier = order.isAscending() ? hubTransfer.timeTaken.asc() : hubTransfer.timeTaken.desc();
+                orderSpecifiers.add(orderSpecifier);
+            } else if (order.getProperty().equals("distance")) {
+                // 다른 필드에 대해서도 처리
+                OrderSpecifier<?> orderSpecifier = order.isAscending() ? hubTransfer.distance.asc() : hubTransfer.distance.desc();
+                orderSpecifiers.add(orderSpecifier);
+            } else if(order.getProperty().equals("id")) {
+                OrderSpecifier<?> orderSpecifier = order.isAscending() ? hubTransfer.id.asc() : hubTransfer.id.desc();
+                orderSpecifiers.add(orderSpecifier);
+            } else {
+                OrderSpecifier<?> orderSpecifier = order.isAscending() ? hubTransfer.endHub.name.asc() : hubTransfer.endHub.name.desc();
+                orderSpecifiers.add(orderSpecifier);
+            }
+        }
+        return orderSpecifiers.toArray(new OrderSpecifier[0]);
+    }
+
 }

--- a/hub/src/main/java/com/logistcshub/hub/hub_transfer/infrastructure/JpaHubTransferRepository.java
+++ b/hub/src/main/java/com/logistcshub/hub/hub_transfer/infrastructure/JpaHubTransferRepository.java
@@ -7,5 +7,5 @@ import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JpaHubTransferRepository extends JpaRepository<HubTransfer, UUID> {
-    boolean existsByStartHubAndEndHubAndDeletedFalse(Hub startHub, Hub endHub);
+    boolean existsByStartHubAndEndHubAndIsDeletedFalse(Hub startHub, Hub endHub);
 }

--- a/hub/src/main/java/com/logistcshub/hub/hub_transfer/presentation/HubTransferController.java
+++ b/hub/src/main/java/com/logistcshub/hub/hub_transfer/presentation/HubTransferController.java
@@ -1,19 +1,26 @@
 package com.logistcshub.hub.hub_transfer.presentation;
 
 import static com.logistcshub.hub.common.domain.model.type.ResponseMessage.SUCCESS_CREATE_HUB_TRANSFER;
+import static com.logistcshub.hub.common.domain.model.type.ResponseMessage.SUCCESS_SEARCH_HUB_TRANSFERS;
 
 import com.logistcshub.hub.common.domain.model.dtos.SuccessResponse;
 import com.logistcshub.hub.hub_transfer.application.dtos.AddHubTransferResponseDto;
+import com.logistcshub.hub.hub_transfer.application.dtos.HubTransferPageDto;
 import com.logistcshub.hub.hub_transfer.application.service.HubTransferService;
+import com.logistcshub.hub.hub_transfer.domain.model.HubTransfer;
 import com.logistcshub.hub.hub_transfer.presentation.request.AddHubTransferRequestDto;
 import java.util.List;
+import java.util.UUID;
+
+import com.querydsl.core.types.Predicate;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.querydsl.binding.QuerydslPredicate;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.data.web.PagedModel;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequestMapping("/api/hub-transfers")
 @RestController
@@ -30,6 +37,20 @@ public class HubTransferController {
 
         return ResponseEntity.ok().body(
                 SuccessResponse.of(SUCCESS_CREATE_HUB_TRANSFER, hubTransferService.addHubTransfer(request, role, userId))
+        );
+    }
+
+    @GetMapping
+    public ResponseEntity<SuccessResponse<HubTransferPageDto>> searchHubTransfer(@RequestParam(required = false) List<UUID> idList,
+                                                                                 @QuerydslPredicate(root = HubTransfer.class) Predicate predicate,
+                                                                                 @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
+                                                                                 @RequestHeader(value = "X-USER-ID") Long userId,
+                                                                                 @RequestHeader(value = "X-USER-ROLE") String role) {
+        userId = 1L;
+        role = "MASTER";
+
+        return ResponseEntity.ok().body(
+                SuccessResponse.of(SUCCESS_SEARCH_HUB_TRANSFERS, hubTransferService.searchHubTransfer(idList, predicate, pageable, role, userId))
         );
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #57 

## 📝작업 내용

> Hub-Transfer 검색 기능 추가하였습니다.
튜터님의 강의 자료를 참고하여 Predicate와 Pageable를 사용하는 검색을 만들었습니다.
사용 가능한 파라미터
- idList : 아이디 리스트 ( UUID라서 많아지면 300자 이상이 되어 오류가 날 것 같습니다.)
- startHub: 시작 허브 UUID
- endHub: 도착 허브 UUID
- timeTaken
  - [gte] : 최소 시간
  - [lte] : 최대 시간
- distance
  - [gte] : 최소 거리
  - [lte] : 최대 거리
- page : 페이지 번호
- size : 페이지 사이즈
- sort 
  - id : 아이디로 정렬
  - startHub : 시작 허브 이름으로 정렬
  - endHub : 도착 허브 이름으로 정렬
  - timeTaken : 예상 이동 시간으로 정렬
  - distance : 예상 거리로 정렬
  - asc
  - desc

![image](https://github.com/user-attachments/assets/513f43f3-a898-412b-a63e-1a56f38e5cde)

