### PR TITLE
Feat: 배송 담당자 생성하는 스케줄링 추가 및 배송 담당자 배정 후 슬랙 이벤트 발행하는 로직 추가

### DIFF
--- a/delivery/src/main/java/com/logistics/delivery/DeliveryApplication.java
+++ b/delivery/src/main/java/com/logistics/delivery/DeliveryApplication.java
@@ -3,7 +3,9 @@ package com.logistics.delivery;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @EnableFeignClients
 @SpringBootApplication
 public class DeliveryApplication {

--- a/delivery/src/main/java/com/logistics/delivery/application/dto/event/EventType.java
+++ b/delivery/src/main/java/com/logistics/delivery/application/dto/event/EventType.java
@@ -7,4 +7,5 @@ public enum EventType {
     ORDER_CREATED,
     ORDER_DELETED,
     DELIVERY_CREATED,
+    SLACK_CREATED,
 }

--- a/delivery/src/main/java/com/logistics/delivery/application/dto/event/SlackCreateEvent.java
+++ b/delivery/src/main/java/com/logistics/delivery/application/dto/event/SlackCreateEvent.java
@@ -10,7 +10,9 @@ public record SlackCreateEvent(
         UUID deliveryId, // 배송 ID
         Long deliveryManagerId, // 배송 담당자 ID
         String deliveryManagerName, // 배송 담당자 이름
-        String deliveryManagerSlackId // 배송 담당자 slack Id
+        String deliveryManagerSlackId, // 배송 담당자 slack Id
+        UUID startHubId, // 출발 허브 ID,
+        UUID endHubId // 도착 허브 ID
 ) {
     public static SlackCreateEvent of(DeliveryRoute deliveryRoute, DeliveryManagerResponse managerResponse) {
         return new SlackCreateEvent(
@@ -18,7 +20,9 @@ public record SlackCreateEvent(
                 deliveryRoute.getDeliveryId(),
                 managerResponse.id(),
                 managerResponse.name(),
-                managerResponse.slackId()
+                managerResponse.slackId(),
+                deliveryRoute.getStartHubId(),
+                deliveryRoute.getEndHubId()
         );
     }
 }

--- a/delivery/src/main/java/com/logistics/delivery/application/dto/event/SlackCreateEvent.java
+++ b/delivery/src/main/java/com/logistics/delivery/application/dto/event/SlackCreateEvent.java
@@ -1,0 +1,24 @@
+package com.logistics.delivery.application.dto.event;
+
+import com.logistics.delivery.application.dto.user.DeliveryManagerResponse;
+import com.logistics.delivery.domain.model.DeliveryRoute;
+
+import java.util.UUID;
+
+public record SlackCreateEvent(
+        EventType eventType,
+        UUID deliveryId, // 배송 ID
+        Long deliveryManagerId, // 배송 담당자 ID
+        String deliveryManagerName, // 배송 담당자 이름
+        String deliveryManagerSlackId // 배송 담당자 slack Id
+) {
+    public static SlackCreateEvent of(DeliveryRoute deliveryRoute, DeliveryManagerResponse managerResponse) {
+        return new SlackCreateEvent(
+                EventType.SLACK_CREATED,
+                deliveryRoute.getDeliveryId(),
+                managerResponse.id(),
+                managerResponse.name(),
+                managerResponse.slackId()
+        );
+    }
+}

--- a/delivery/src/main/java/com/logistics/delivery/application/dto/event/consume/SlackCreateConsume.java
+++ b/delivery/src/main/java/com/logistics/delivery/application/dto/event/consume/SlackCreateConsume.java
@@ -9,6 +9,8 @@ public record SlackCreateConsume(
         UUID deliveryId, // 배송 ID
         Long deliveryManagerId, // 배송 담당자 ID
         String deliveryManagerName, // 배송 담당자 이름
-        String deliveryManagerSlackId // 배송 담당자 slack Id
+        String deliveryManagerSlackId, // 배송 담당자 slack Id,
+        UUID startHubId, // 출발 허브 ID,
+        UUID endHubId // 도착 허브 ID
 ) {
 }

--- a/delivery/src/main/java/com/logistics/delivery/application/dto/event/consume/SlackCreateConsume.java
+++ b/delivery/src/main/java/com/logistics/delivery/application/dto/event/consume/SlackCreateConsume.java
@@ -1,0 +1,14 @@
+package com.logistics.delivery.application.dto.event.consume;
+
+import com.logistics.delivery.application.dto.event.EventType;
+
+import java.util.UUID;
+
+public record SlackCreateConsume(
+        EventType eventType,
+        UUID deliveryId, // 배송 ID
+        Long deliveryManagerId, // 배송 담당자 ID
+        String deliveryManagerName, // 배송 담당자 이름
+        String deliveryManagerSlackId // 배송 담당자 slack Id
+) {
+}

--- a/delivery/src/main/java/com/logistics/delivery/application/dto/user/DeliveryManagerResponse.java
+++ b/delivery/src/main/java/com/logistics/delivery/application/dto/user/DeliveryManagerResponse.java
@@ -3,8 +3,9 @@ package com.logistics.delivery.application.dto.user;
 import java.util.UUID;
 
 public record DeliveryManagerResponse(
-        UUID id,              // 배송 담당자 ID
+        Long id,              // 배송 담당자 ID
         String name,          // 배송 담당자 이름
+        UUID hubId,           // 배송 담당자의 현재 위치한 hubId
         String slackId,       // 배송 담당자 Slack ID
         int sequence,         // 순번
         String type           // 배송 담당자 타입 (허브/업체 구분)

--- a/delivery/src/main/java/com/logistics/delivery/application/message/SlackMessageListener.java
+++ b/delivery/src/main/java/com/logistics/delivery/application/message/SlackMessageListener.java
@@ -1,0 +1,28 @@
+package com.logistics.delivery.application.message;
+
+import com.logistics.delivery.application.dto.event.EventType;
+import com.logistics.delivery.application.dto.event.consume.SlackCreateConsume;
+import com.logistics.delivery.application.util.EventUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SlackMessageListener {
+
+    // TODO: private final 해당 부분에 서비스를 추가하시면 될 것 같습니다!
+
+    @RabbitListener(queues = "${message.queues.slack}")
+    public void handleSlackCreateEvent(String message) {
+        EventType eventType = EventUtil.extractEventType(message);
+        switch (eventType) {
+            case SLACK_CREATED -> {
+                // 슬랙 메시지 생성 로직 호출
+                SlackCreateConsume slackCreateConsume = EventUtil.deserializeEvent(message, SlackCreateConsume.class);
+                // TODO: 주입받은 서비스의 메서드를 통해서 슬랙 메시지를 만드시면 될 것 같습니다.
+            }
+        }
+    }
+
+}

--- a/delivery/src/main/java/com/logistics/delivery/application/scheduler/DeliveryAssignmentScheduler.java
+++ b/delivery/src/main/java/com/logistics/delivery/application/scheduler/DeliveryAssignmentScheduler.java
@@ -1,0 +1,30 @@
+package com.logistics.delivery.application.scheduler;
+
+import com.logistics.delivery.domain.service.DeliveryManagerService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DeliveryAssignmentScheduler {
+
+    private final DeliveryManagerService deliveryManagerService;
+
+    /**
+     * 배정되지 않은 경로를 확인하고 배송 담당자를 배정
+     */
+    @Scheduled(fixedRateString = "${scheduler.delivery-assignment.interval}")
+    public void assignManagersToPendingRoutes() {
+        try {
+            log.info("Starting scheduled task to assign delivery managers.");
+            deliveryManagerService.assignManagersForPendingRoutes();
+            log.info("Completed scheduled task for assigning delivery managers.");
+        } catch (Exception e) {
+            log.error("Error occurred during delivery manager assignment: {}", e.getMessage(), e);
+        }
+    }
+
+}

--- a/delivery/src/main/java/com/logistics/delivery/application/service/DeliveryManagerServiceImpl.java
+++ b/delivery/src/main/java/com/logistics/delivery/application/service/DeliveryManagerServiceImpl.java
@@ -132,7 +132,7 @@ public class DeliveryManagerServiceImpl implements DeliveryManagerService {
             // 이벤트 생성
             SlackCreateEvent event = SlackCreateEvent.of(route, assignedManager);
 
-            // 슬랙 이벤트 생성
+            // 슬랙 이벤트 발행
             rabbitTemplate.convertAndSend(
                     rabbitProperties.getExchange().getDelivery(),
                     event

--- a/delivery/src/main/java/com/logistics/delivery/domain/model/DeliveryRoute.java
+++ b/delivery/src/main/java/com/logistics/delivery/domain/model/DeliveryRoute.java
@@ -25,7 +25,7 @@ public class DeliveryRoute extends AuditingFields {
     private UUID deliveryId;
 
     @Comment("배송 담당자 ID")
-    private UUID deliveryManagerId;
+    private Long deliveryManagerId;
 
     @Comment("배송 경로 상 순번")
     private int sequence;
@@ -85,7 +85,7 @@ public class DeliveryRoute extends AuditingFields {
      *
      * @param assignedManagerId 배송 담당자 ID
      */
-    public void assignManager(UUID assignedManagerId) {
+    public void assignManager(Long assignedManagerId) {
         this.deliveryManagerId = assignedManagerId;
         this.status = RouteStatus.ASSIGNED;
     }

--- a/delivery/src/main/java/com/logistics/delivery/domain/repository/DeliveryRouteRepository.java
+++ b/delivery/src/main/java/com/logistics/delivery/domain/repository/DeliveryRouteRepository.java
@@ -18,7 +18,7 @@ public interface DeliveryRouteRepository {
 
     List<DeliveryRoute> findPendingRoutes();
 
-    Optional<UUID> findAssignedManagerByRoute(UUID startHubId, UUID endHubId);
+    Optional<Long> findAssignedManagerByRoute(UUID startHubId, UUID endHubId);
 
-    List<UUID> findAssignedManagerIds();
+    List<Long> findAssignedManagerIds();
 }

--- a/delivery/src/main/java/com/logistics/delivery/infrastructure/client/HubClient.java
+++ b/delivery/src/main/java/com/logistics/delivery/infrastructure/client/HubClient.java
@@ -3,6 +3,7 @@ package com.logistics.delivery.infrastructure.client;
 import com.logistics.delivery.application.dto.hub.HubToHubResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.UUID;
 
@@ -10,5 +11,6 @@ import java.util.UUID;
 public interface HubClient {
 
     @GetMapping("/api/hub-transfers/routes")
-    HubToHubResponse getHubToHubRoutes(UUID startHubId, UUID endHubId);
+    HubToHubResponse getHubToHubRoutes(@RequestParam("start") UUID startHubId,
+                                       @RequestParam("end") UUID endHubId);
 }

--- a/delivery/src/main/java/com/logistics/delivery/infrastructure/config/RabbitMQConfig.java
+++ b/delivery/src/main/java/com/logistics/delivery/infrastructure/config/RabbitMQConfig.java
@@ -25,8 +25,18 @@ public class RabbitMQConfig {
     }
 
     @Bean
+    public Queue slackQueue() {
+        return new Queue(properties.getQueues().getSlack());
+    }
+
+    @Bean
     public Binding orderBinding(Queue orderQueue, FanoutExchange deliveryExchange) {
         return BindingBuilder.bind(orderQueue).to(deliveryExchange);
+    }
+
+    @Bean
+    public Binding slackBinding(Queue slackQueue, FanoutExchange deliveryExchange) {
+        return BindingBuilder.bind(slackQueue).to(deliveryExchange);
     }
 
 }

--- a/delivery/src/main/java/com/logistics/delivery/infrastructure/config/RabbitMQProperties.java
+++ b/delivery/src/main/java/com/logistics/delivery/infrastructure/config/RabbitMQProperties.java
@@ -24,6 +24,7 @@ public class RabbitMQProperties {
     @Setter
     public static class Queues {
         private String order;
+        private String slack;
     }
 
 }

--- a/delivery/src/main/java/com/logistics/delivery/infrastructure/repository/DeliveryRouteRepositoryImpl.java
+++ b/delivery/src/main/java/com/logistics/delivery/infrastructure/repository/DeliveryRouteRepositoryImpl.java
@@ -41,12 +41,12 @@ public class DeliveryRouteRepositoryImpl implements DeliveryRouteRepository {
     }
 
     @Override
-    public Optional<UUID> findAssignedManagerByRoute(UUID startHubId, UUID endHubId) {
+    public Optional<Long> findAssignedManagerByRoute(UUID startHubId, UUID endHubId) {
         return jpaDeliveryRouteRepository.findAssignedManagerByRoute(startHubId, endHubId);
     }
 
     @Override
-    public List<UUID> findAssignedManagerIds() {
+    public List<Long> findAssignedManagerIds() {
         return jpaDeliveryRouteRepository.findAssignedManagerIds();
     }
 }

--- a/delivery/src/main/java/com/logistics/delivery/infrastructure/repository/JpaDeliveryRouteRepository.java
+++ b/delivery/src/main/java/com/logistics/delivery/infrastructure/repository/JpaDeliveryRouteRepository.java
@@ -16,8 +16,8 @@ public interface JpaDeliveryRouteRepository extends JpaRepository<DeliveryRoute,
     @Query("SELECT dr.deliveryManagerId FROM DeliveryRoute dr " +
             "WHERE dr.startHubId = :startHubId AND dr.endHubId = :endHubId " +
             "AND dr.status = 'ASSIGNED'")
-    Optional<UUID> findAssignedManagerByRoute(UUID startHubId, UUID endHubId);
+    Optional<Long> findAssignedManagerByRoute(UUID startHubId, UUID endHubId);
 
     @Query("SELECT DISTINCT dr.deliveryManagerId FROM DeliveryRoute dr WHERE dr.status = 'ASSIGNED'")
-    List<UUID> findAssignedManagerIds();
+    List<Long> findAssignedManagerIds();
 }

--- a/delivery/src/main/resources/application-infra.yml
+++ b/delivery/src/main/resources/application-infra.yml
@@ -3,5 +3,6 @@ message:
     delivery: ${MESSAGE_EXCHANGE_DELIVERY}
   queues:
     order: ${MESSAGE_QUEUE_ORDER}
+    slack: ${MESSAGE_QUEUE_SLACK}
   receive:
     delivery: ${MESSAGE_RECEIVE_QUEUE_DELIVERY}

--- a/delivery/src/main/resources/application.yml
+++ b/delivery/src/main/resources/application.yml
@@ -24,3 +24,7 @@ eureka:
 
 delivery:
   max-waiting-time-minutes: ${DELIVERY_MAX_WAITING_TIME_MINUTES}
+
+scheduler:
+  delivery-assignment:
+    interval: ${DELIVERY_ASSIGNMENT_SCHEDULER_INTERVAL}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #77 

## 📝작업 내용

> 배송 담당자 생성하는 스케줄링 추가
> 배송 담당자 배정 후 슬랙 이벤트 발행하는 로직 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 배송 담당자 배정 완료 후 슬랙 이벤트 발행 플로우

1. DeliveryManagerServiceImpl -> assignManagerToGroupedRoutes() 메서드 내 

```java
// 이벤트 생성
  SlackCreateEvent event = SlackCreateEvent.of(route, assignedManager);

  // 슬랙 이벤트 발행
  rabbitTemplate.convertAndSend(
          rabbitProperties.getExchange().getDelivery(),
          event
  );
```
            
 에서 이벤트를 발행 합니다.
 
 3. SlackMessageListener

```java
@Component
@RequiredArgsConstructor
public class SlackMessageListener {

    // TODO: private final 해당 부분에 서비스를 추가하시면 될 것 같습니다!

    @RabbitListener(queues = "${message.queues.slack}")
    public void handleSlackCreateEvent(String message) {
        EventType eventType = EventUtil.extractEventType(message);
        switch (eventType) {
            case SLACK_CREATED -> {
                // 슬랙 메시지 생성 로직 호출
                SlackCreateConsume slackCreateConsume = EventUtil.deserializeEvent(message, SlackCreateConsume.class);
                // TODO: 주입받은 서비스의 메서드를 통해서 슬랙 메시지를 만드시면 될 것 같습니다.
            }
        }
    }

}
```

에서 TODO부분을 작성해 주시면 될 것 같습니다! 